### PR TITLE
docs(readme): update project description and add badges for license, CI, and contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-∞-orange.svg?style=flat-square)](#contributors)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![CI](https://github.com/The-Purple-Movement/WikiSyllabus/actions/workflows/mdbook.yml/badge.svg)](https://github.com/The-Purple-Movement/WikiSyllabus/actions/workflows/mdbook.yml)
 [![Open Issues](https://img.shields.io/github/issues/The-Purple-Movement/WikiSyllabus)](https://github.com/The-Purple-Movement/WikiSyllabus/issues)
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+
+# 📚 WikiSyllabus
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-∞-orange.svg?style=flat-square)](#contributors)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![CI](https://github.com/The-Purple-Movement/WikiSyllabus/actions/workflows/mdbook.yml/badge.svg)](https://github.com/The-Purple-Movement/WikiSyllabus/actions/workflows/mdbook.yml)
+[![Open Issues](https://img.shields.io/github/issues/The-Purple-Movement/WikiSyllabus)](https://github.com/The-Purple-Movement/WikiSyllabus/issues)
+
+---
+
+**WikiSyllabus** is the **open-source Wikipedia of university syllabi** — a global academic repository that makes it easy to search, access, and contribute syllabi from universities around the world.
+
+---
+
+## 🌟 Vision
+
+To provide the **core database of every university syllabus** — organized, markdown-first, and community-driven.
+
+---
+
+## 💬 What We Advocate
+
+- 📖 **Open-book examinations**
+- 🔁 **Flipped learning** and **flipped classrooms**
+- 🤝 **Collaborative, community-driven education**
+- 🔓 **Free and open access to academic information**
+
+---
+
+## 🧑‍💻 What We Are
+
+WikiSyllabus is a **fully open-source initiative** maintained by volunteers from the global educational and open-source communities. Contributions are welcome from anyone.
+
+---
+
+## 📦 Folder Structure
+
+Each syllabus file is organized in the following structure:
+
+```
+
+/university/branch/year/semester/xx.md
+
+```
+
+✅ Example:
+
+```
+
+/ktu/computer-science/2019/s8/01.md
+
+````
+
+---
+
+## 📝 Markdown File Format
+
+Each `.md` file must begin with **YAML frontmatter** like this:
+
+```yaml
+---
+country: "india"
+university: "ktu"
+branch: "computer-science"
+version: "2019"
+semester: 8
+course_code: "cst402"
+course_title: "distributed computing"
+language: "english"
+contributor: "@your-github-username"
+---
+````
+
+Then continue with content like objectives, units, textbooks, references, etc.
+
+---
+
+## 🙌 How to Contribute
+
+If you’re ready to contribute, check out our 👉 [**Contribution Guide**](./CONTRIBUTION.md)
+
+---
+
+## 🤝 Code of Conduct
+
+Please read our 👉 [**Code of Conduct**](./CODE_OF_CONDUCT.md)
+We’re committed to maintaining a safe, inclusive, and respectful environment for all.
+
+---
+
+## ⚖ License
+
+This project is licensed under the [MIT License](./LICENSE).
+
+---
+
+## 📬 Contact & Help
+
+Open an [issue](https://github.com/The-Purple-Movement/WikiSyllabus/issues) or tag a maintainer (e.g., `@admin`) in your PR for support.
+
+---
+
+### 💡 Together, let’s build the world’s most open academic resource.


### PR DESCRIPTION
- Reworded intro to reflect WikiSyllabus as an existing global project
- Added GitHub-flavored markdown badges for MIT license, CI, and contributors
- Linked to existing CONTRIBUTION.md and CODE_OF_CONDUCT.md files
- Refined tone from "aiming" to confident present tense