### PR TITLE
MIT Computer Science 2025 S[1-8]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+agent.md

--- a/universities/mit/cse/2025/S1/01.md
+++ b/universities/mit/cse/2025/S1/01.md
@@ -5,7 +5,7 @@ branch: "computer-science"
 version: "2025"
 semester: 1
 course_code: "6.100A"
-course_title: "Introduction to Computer Science Programming in Python"
+course_title: "Introduction-to-Computer-Science-Programming-in-Python"
 language: "english"
 contributor: "@deepusnath"
 ---

--- a/universities/mit/cse/2025/S1/01.md
+++ b/universities/mit/cse/2025/S1/01.md
@@ -1,16 +1,13 @@
 ---
 country: "usa"
 university: "mit"
-branch: "cse"
+branch: "computer-science"
 version: "2025"
 semester: 1
 course_code: "6.100A"
 course_title: "Introduction to Computer Science Programming in Python"
-units: "6"
-level: "U"
-prerequisites: []
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S1/01.md
+++ b/universities/mit/cse/2025/S1/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 1
+course_code: "6.100A"
+course_title: "Introduction to Computer Science Programming in Python"
+units: "6"
+level: "U"
+prerequisites: []
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Introduction to computer science programming in Python serves as the foundation for the Computer Science and Engineering major. This course introduces computational thinking and basic programming concepts using Python, preparing students for more advanced coursework in algorithms, software construction, and computer systems.
+
+## Learning Objectives
+
+- Master fundamental programming concepts including variables, functions, and control structures
+- Develop computational thinking and problem-solving skills
+- Understand basic data structures and their applications
+- Learn to write, test, and debug Python programs
+- Apply programming concepts to solve real-world problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Introduction to Programming and Python
+- Variables, expressions, and basic data types
+- Input/output operations
+- Programming environments and tools
+
+**Weeks 3-4**: Control Structures
+- Conditional statements (if/else)
+- Loops (for and while)
+- Boolean logic and operators
+
+**Weeks 5-6**: Functions and Modularity
+- Function definition and calling
+- Parameters and return values
+- Scope and local variables
+
+**Weeks 7-8**: Data Structures
+- Strings and string manipulation
+- Lists and list operations
+- Dictionaries and their uses
+
+**Weeks 9-10**: File Processing and Error Handling
+- Reading and writing files
+- Exception handling
+- Input validation
+
+**Weeks 11-12**: Problem Solving and Applications
+- Algorithm design strategies
+- Debugging techniques
+- Project development
+
+## Assessment & Workload
+
+6 units of coursework typically including problem sets, programming assignments, and examinations. Specific workload details not specified in source materials.
+
+## Recommended Texts & Resources
+
+- Official MIT OpenCourseWare materials
+- Python programming resources and documentation
+- Online programming practice platforms
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT Subject Catalog](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S1/02.md
+++ b/universities/mit/cse/2025/S1/02.md
@@ -1,7 +1,7 @@
 ---
 country: "usa"
 university: "mit"
-branch: "cse"
+branch: "computer-science"
 version: "2025"
 semester: 1
 course_code: "18.06"
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["18.02"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S1/02.md
+++ b/universities/mit/cse/2025/S1/02.md
@@ -5,7 +5,7 @@ branch: "computer-science"
 version: "2025"
 semester: 1
 course_code: "18.06"
-course_title: "Linear Algebra"
+course_title: "Linear-Algebra"
 units: "12"
 level: "U"
 prerequisites: ["18.02"]

--- a/universities/mit/cse/2025/S1/02.md
+++ b/universities/mit/cse/2025/S1/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 1
+course_code: "18.06"
+course_title: "Linear Algebra"
+units: "12"
+level: "U"
+prerequisites: ["18.02"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Linear Algebra provides the mathematical foundation essential for computer science, covering vector spaces, matrices, eigenvalues, and linear transformations. This course is crucial for understanding machine learning, computer graphics, data analysis, and many other areas of computer science.
+
+## Learning Objectives
+
+- Master vector operations and linear combinations
+- Understand matrix operations, determinants, and inverses
+- Learn eigenvalues, eigenvectors, and diagonalization
+- Apply linear algebra concepts to solve systems of equations
+- Develop geometric intuition for linear transformations
+
+## Syllabus Outline
+
+**Weeks 1-2**: Vectors and Linear Combinations
+- Vector addition and scalar multiplication
+- Linear combinations and span
+- Linear independence
+
+**Weeks 3-4**: Matrix Operations
+- Matrix multiplication and properties
+- Inverse matrices and determinants
+- Elementary row operations
+
+**Weeks 5-6**: Vector Spaces and Subspaces
+- Column space and nullspace
+- Basis and dimension
+- The four fundamental subspaces
+
+**Weeks 7-8**: Orthogonality
+- Orthogonal vectors and subspaces
+- Projections and least squares
+- Gram-Schmidt process
+
+**Weeks 9-10**: Eigenvalues and Eigenvectors
+- Characteristic polynomial
+- Diagonalization
+- Applications to differential equations
+
+**Weeks 11-12**: Applications
+- Principal component analysis
+- Markov matrices and steady state
+- Linear transformations and computer graphics
+
+## Assessment & Workload
+
+12 units including problem sets, exams, and computational exercises. Students typically spend significant time on both theoretical proofs and computational applications.
+
+## Recommended Texts & Resources
+
+- Gilbert Strang's "Introduction to Linear Algebra"
+- MIT OpenCourseWare 18.06 materials
+- MATLAB/Python computational exercises
+
+## References
+
+- [MIT Course 18.06](https://catalog.mit.edu/subjects/18/)
+- [MIT Mathematics Subject Listings](https://catalog.mit.edu/subjects/18/)

--- a/universities/mit/cse/2025/S2/01.md
+++ b/universities/mit/cse/2025/S2/01.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.100A"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S2/01.md
+++ b/universities/mit/cse/2025/S2/01.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 2
 course_code: "6.1010"
-course_title: "Fundamentals of Programming"
+course_title: "Fundamentals-of-Programming"
 units: "12"
 level: "U"
 prerequisites: ["6.100A"]

--- a/universities/mit/cse/2025/S2/01.md
+++ b/universities/mit/cse/2025/S2/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 2
+course_code: "6.1010"
+course_title: "Fundamentals of Programming"
+units: "12"
+level: "U"
+prerequisites: ["6.100A"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Fundamentals of Programming builds upon introductory programming concepts to develop deeper understanding of program design, testing, and debugging. This course satisfies the Laboratory Requirement and emphasizes hands-on programming experience with larger projects and collaborative development practices.
+
+## Learning Objectives
+
+- Design and implement medium-scale software projects
+- Apply systematic debugging and testing methodologies
+- Understand program organization and modular design
+- Develop collaborative programming skills
+- Master advanced programming constructs and patterns
+
+## Syllabus Outline
+
+**Weeks 1-2**: Program Design and Structure
+- Software design principles
+- Program organization and modularity
+- Documentation and coding standards
+
+**Weeks 3-4**: Advanced Data Structures
+- Lists, dictionaries, and sets
+- Object-oriented programming concepts
+- Classes and methods
+
+**Weeks 5-6**: Testing and Debugging
+- Unit testing frameworks
+- Debugging strategies and tools
+- Error handling and validation
+
+**Weeks 7-8**: Algorithms and Efficiency
+- Basic algorithm analysis
+- Search and sort algorithms
+- Time and space complexity
+
+**Weeks 9-10**: Collaborative Development
+- Version control systems
+- Code review practices
+- Team programming projects
+
+**Weeks 11-12**: Project Development
+- Large-scale programming project
+- Integration and deployment
+- Performance optimization
+
+## Assessment & Workload
+
+12 units including programming assignments, lab exercises, collaborative projects, and examinations. Significant hands-on laboratory component satisfies MIT's Laboratory Requirement.
+
+## Recommended Texts & Resources
+
+- Course-specific programming materials
+- Python development tools and environments
+- Collaborative development platforms
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S2/02.md
+++ b/universities/mit/cse/2025/S2/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 2
+course_code: "6.1200"
+course_title: "Mathematics for Computer Science"
+units: "12"
+level: "U"
+prerequisites: ["18.01"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Mathematics for Computer Science introduces mathematical concepts essential for computer science, including discrete mathematics, logic, proofs, and probability. This course provides the theoretical foundation for algorithm analysis, cryptography, and many other areas of computer science.
+
+## Learning Objectives
+
+- Master mathematical proof techniques and logical reasoning
+- Understand discrete mathematical structures and their applications
+- Learn probability theory and its applications to computer science
+- Develop skills in mathematical modeling and analysis
+- Apply mathematical concepts to solve computational problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Logic and Proofs
+- Propositional and predicate logic
+- Proof techniques: direct, contradiction, induction
+- Mathematical reasoning and rigor
+
+**Weeks 3-4**: Sets, Relations, and Functions
+- Set theory and operations
+- Relations and their properties
+- Functions and their applications
+
+**Weeks 5-6**: Number Theory and Cryptography
+- Modular arithmetic
+- Prime numbers and factorization
+- RSA cryptosystem
+
+**Weeks 7-8**: Graph Theory
+- Graph representations and properties
+- Trees and spanning trees
+- Graph algorithms and applications
+
+**Weeks 9-10**: Probability Theory
+- Sample spaces and events
+- Conditional probability and independence
+- Random variables and expectation
+
+**Weeks 11-12**: Applications to Computer Science
+- Probabilistic algorithms
+- Hashing and load balancing
+- Mathematical analysis of algorithms
+
+## Assessment & Workload
+
+12 units including problem sets, proofs, mathematical modeling exercises, and examinations. Emphasis on developing mathematical maturity and proof-writing skills.
+
+## Recommended Texts & Resources
+
+- Course textbook on discrete mathematics
+- Supplementary materials on proof techniques
+- Mathematical software for verification
+
+## References
+
+- [MIT Course 6.1200[J]](https://catalog.mit.edu/subjects/6/)
+- [MIT Mathematics Cross-listing 18.062[J]](https://catalog.mit.edu/subjects/18/)

--- a/universities/mit/cse/2025/S2/02.md
+++ b/universities/mit/cse/2025/S2/02.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 2
 course_code: "6.1200"
-course_title: "Mathematics for Computer Science"
+course_title: "Mathematics-for-Computer-Science"
 units: "12"
 level: "U"
 prerequisites: ["18.01"]

--- a/universities/mit/cse/2025/S2/02.md
+++ b/universities/mit/cse/2025/S2/02.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["18.01"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S3/01.md
+++ b/universities/mit/cse/2025/S3/01.md
@@ -10,7 +10,7 @@ units: "15"
 level: "U"
 prerequisites: ["6.1010"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S3/01.md
+++ b/universities/mit/cse/2025/S3/01.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 3
 course_code: "6.1020"
-course_title: "Software Construction"
+course_title: "Software-Construction"
 units: "15"
 level: "U"
 prerequisites: ["6.1010"]

--- a/universities/mit/cse/2025/S3/01.md
+++ b/universities/mit/cse/2025/S3/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 3
+course_code: "6.1020"
+course_title: "Software Construction"
+units: "15"
+level: "U"
+prerequisites: ["6.1010"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Software Construction focuses on techniques and tools for building large, robust, and maintainable software systems. This course emphasizes software engineering principles, design patterns, testing strategies, and collaborative development practices essential for professional software development.
+
+## Learning Objectives
+
+- Master software design principles and architectural patterns
+- Develop expertise in testing, debugging, and code quality
+- Learn version control and collaborative development workflows
+- Understand software lifecycle and project management
+- Apply engineering principles to large-scale software systems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Software Design Principles
+- Abstraction and modularity
+- Design patterns and their applications
+- Interface design and specifications
+
+**Weeks 3-4**: Code Quality and Maintainability
+- Code review practices
+- Refactoring techniques
+- Documentation and style guidelines
+
+**Weeks 5-6**: Testing and Verification
+- Unit testing and test-driven development
+- Integration and system testing
+- Automated testing frameworks
+
+**Weeks 7-8**: Version Control and Collaboration
+- Git and distributed version control
+- Branching strategies and merge workflows
+- Code collaboration and team development
+
+**Weeks 9-10**: Software Architecture
+- System design and architecture patterns
+- Scalability and performance considerations
+- Security and reliability principles
+
+**Weeks 11-12**: Project Development
+- Large-scale software project
+- Agile development methodologies
+- Deployment and maintenance
+
+## Assessment & Workload
+
+15 units including programming assignments, design exercises, collaborative projects, and examinations. Substantial team-based software development component.
+
+## Recommended Texts & Resources
+
+- Software engineering textbooks and design pattern guides
+- Development tools and integrated environments
+- Project management and collaboration platforms
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S3/02.md
+++ b/universities/mit/cse/2025/S3/02.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 3
 course_code: "6.1910"
-course_title: "Computation Structures"
+course_title: "Computation-Structures"
 units: "12"
 level: "U"
 prerequisites: ["6.100A", "18.03"]

--- a/universities/mit/cse/2025/S3/02.md
+++ b/universities/mit/cse/2025/S3/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 3
+course_code: "6.1910"
+course_title: "Computation Structures"
+units: "12"
+level: "U"
+prerequisites: ["6.100A", "18.03"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Computation Structures introduces the design and implementation of digital systems, bridging the gap between programming and computer hardware. This course covers logic design, computer architecture, assembly language programming, and the fundamental principles underlying modern computing systems.
+
+## Learning Objectives
+
+- Understand digital logic design and Boolean algebra
+- Learn computer architecture and instruction set design
+- Master assembly language programming concepts
+- Develop skills in hardware-software interaction
+- Apply engineering principles to computing system design
+
+## Syllabus Outline
+
+**Weeks 1-2**: Digital Logic and Boolean Algebra
+- Logic gates and combinational circuits
+- Boolean algebra and logic minimization
+- Multiplexers, decoders, and arithmetic circuits
+
+**Weeks 3-4**: Sequential Logic
+- Flip-flops and latches
+- State machines and timing
+- Registers and counters
+
+**Weeks 5-6**: Computer Architecture Fundamentals
+- Von Neumann architecture
+- Instruction set architecture
+- CPU design principles
+
+**Weeks 7-8**: Assembly Language Programming
+- Machine language and assembly syntax
+- Addressing modes and instruction types
+- Subroutines and stack operations
+
+**Weeks 9-10**: Memory Systems
+- Memory hierarchy and cache design
+- Virtual memory concepts
+- Storage systems and I/O
+
+**Weeks 11-12**: Performance and Optimization
+- Pipeline design and hazards
+- Performance analysis and benchmarking
+- System integration and testing
+
+## Assessment & Workload
+
+12 units including logic design exercises, assembly programming assignments, hardware simulation projects, and examinations. Satisfies REST requirement.
+
+## Recommended Texts & Resources
+
+- Computer architecture and digital design textbooks
+- Logic simulation and design tools
+- Assembly language programming environments
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S3/02.md
+++ b/universities/mit/cse/2025/S3/02.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.100A", "18.03"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S4/01.md
+++ b/universities/mit/cse/2025/S4/01.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 4
 course_code: "6.1210"
-course_title: "Introduction to Algorithms"
+course_title: "Introduction-to-Algorithms"
 units: "12"
 level: "U"
 prerequisites: ["6.1200", "6.1010"]

--- a/universities/mit/cse/2025/S4/01.md
+++ b/universities/mit/cse/2025/S4/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 4
+course_code: "6.1210"
+course_title: "Introduction to Algorithms"
+units: "12"
+level: "U"
+prerequisites: ["6.1200", "6.1010"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Introduction to Algorithms provides a comprehensive foundation in algorithmic thinking and analysis. This course covers fundamental algorithms, data structures, and computational complexity, preparing students for advanced work in computer science and software engineering.
+
+## Learning Objectives
+
+- Master fundamental algorithms for searching, sorting, and graph problems
+- Understand algorithmic complexity analysis and Big-O notation
+- Learn advanced data structures and their applications
+- Develop skills in algorithm design and optimization
+- Apply algorithmic thinking to solve computational problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Algorithm Analysis
+- Asymptotic notation and complexity analysis
+- Best, worst, and average case analysis
+- Mathematical foundations for algorithm analysis
+
+**Weeks 3-4**: Sorting and Searching
+- Comparison-based sorting algorithms
+- Linear-time sorting algorithms
+- Binary search and its variants
+
+**Weeks 5-6**: Data Structures
+- Hash tables and collision resolution
+- Binary search trees and balanced trees
+- Heaps and priority queues
+
+**Weeks 7-8**: Graph Algorithms
+- Graph representations and traversal
+- Shortest path algorithms
+- Minimum spanning trees
+
+**Weeks 9-10**: Dynamic Programming
+- Principles of dynamic programming
+- Classic DP problems and solutions
+- Memoization and optimization
+
+**Weeks 11-12**: Advanced Topics
+- Network flows and matching
+- String algorithms
+- Approximation algorithms
+
+## Assessment & Workload
+
+12 units including problem sets, algorithm implementation assignments, complexity analysis exercises, and examinations. Emphasis on both theoretical understanding and practical implementation.
+
+## Recommended Texts & Resources
+
+- "Introduction to Algorithms" by Cormen, Leiserson, Rivest, and Stein
+- MIT OpenCourseWare materials for 6.1210
+- Algorithm visualization and implementation tools
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S4/01.md
+++ b/universities/mit/cse/2025/S4/01.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1200", "6.1010"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S4/02.md
+++ b/universities/mit/cse/2025/S4/02.md
@@ -10,7 +10,7 @@ units: "6"
 level: "U"
 prerequisites: ["6.1010"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S4/02.md
+++ b/universities/mit/cse/2025/S4/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 4
+course_code: "6.1903"
+course_title: "Introduction to Low-level Programming in C and Assembly"
+units: "6"
+level: "U"
+prerequisites: ["6.1010"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Introduction to Low-level Programming in C and Assembly bridges high-level programming concepts with system-level programming. This course provides essential skills for systems programming, embedded systems, and understanding computer architecture from a programmer's perspective.
+
+## Learning Objectives
+
+- Master C programming language and its applications
+- Understand memory management and pointer operations
+- Learn assembly language programming fundamentals
+- Develop skills in system-level programming
+- Apply low-level programming concepts to solve real problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: C Programming Fundamentals
+- C syntax, data types, and operators
+- Functions and parameter passing
+- Arrays and string manipulation
+
+**Weeks 3-4**: Memory Management
+- Pointers and pointer arithmetic
+- Dynamic memory allocation
+- Memory layout and organization
+
+**Weeks 5-6**: System Programming
+- File I/O and system calls
+- Process creation and management
+- Inter-process communication
+
+**Weeks 7-8**: Assembly Language Basics
+- Assembly syntax and instruction formats
+- Register usage and addressing modes
+- Control flow in assembly
+
+**Weeks 9-10**: C-Assembly Integration
+- Calling conventions and stack frames
+- Inline assembly and interfacing
+- Performance optimization techniques
+
+**Weeks 11-12**: Advanced Topics
+- Debugging and profiling tools
+- Embedded systems programming
+- Real-world applications
+
+## Assessment & Workload
+
+6 units including C programming assignments, assembly language exercises, system programming projects, and examinations. Focus on practical programming skills and system understanding.
+
+## Recommended Texts & Resources
+
+- C programming language reference materials
+- Assembly language programming guides
+- System programming tools and environments
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S5/01.md
+++ b/universities/mit/cse/2025/S5/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 5
+course_code: "6.1800"
+course_title: "Computer Systems Engineering"
+units: "12"
+level: "U"
+prerequisites: ["6.1020", "6.1910"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Computer Systems Engineering teaches the design and implementation of complex computer systems. This course covers operating systems principles, distributed systems, performance analysis, and system security, providing students with skills to build and analyze large-scale computing systems.
+
+## Learning Objectives
+
+- Understand operating system design and implementation
+- Learn distributed systems principles and challenges
+- Master performance analysis and optimization techniques
+- Develop skills in system security and reliability
+- Apply engineering principles to complex system design
+
+## Syllabus Outline
+
+**Weeks 1-2**: Operating Systems Fundamentals
+- Process management and scheduling
+- Memory management and virtual memory
+- File systems and storage
+
+**Weeks 3-4**: Concurrency and Synchronization
+- Threads and thread synchronization
+- Deadlock detection and prevention
+- Parallel programming concepts
+
+**Weeks 5-6**: System Performance
+- Performance measurement and analysis
+- Caching and optimization strategies
+- Scalability and bottleneck analysis
+
+**Weeks 7-8**: Distributed Systems
+- Network protocols and communication
+- Consistency and consensus algorithms
+- Fault tolerance and reliability
+
+**Weeks 9-10**: System Security
+- Security threats and vulnerabilities
+- Access control and authentication
+- Cryptographic protocols
+
+**Weeks 11-12**: Advanced Topics
+- Cloud computing architectures
+- Microservices and containerization
+- System design case studies
+
+## Assessment & Workload
+
+12 units including system programming assignments, performance analysis projects, distributed system implementations, and examinations. Emphasis on hands-on system building and analysis.
+
+## Recommended Texts & Resources
+
+- Operating systems and distributed systems textbooks
+- System programming tools and environments
+- Performance analysis and monitoring tools
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S5/01.md
+++ b/universities/mit/cse/2025/S5/01.md
@@ -1,4 +1,5 @@
 ---
+
 country: "usa"
 university: "mit"
 branch: "cse"
@@ -10,7 +11,8 @@ units: "12"
 level: "U"
 prerequisites: ["6.1020", "6.1910"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
+
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S5/01.md
+++ b/universities/mit/cse/2025/S5/01.md
@@ -6,7 +6,7 @@ branch: "cse"
 version: "2025"
 semester: 5
 course_code: "6.1800"
-course_title: "Computer Systems Engineering"
+course_title: "Computer-Systems-Engineering"
 units: "12"
 level: "U"
 prerequisites: ["6.1020", "6.1910"]

--- a/universities/mit/cse/2025/S5/02.md
+++ b/universities/mit/cse/2025/S5/02.md
@@ -6,7 +6,7 @@ branch: "cse"
 version: "2025"
 semester: 5
 course_code: "6.1400"
-course_title: "Computability and Complexity Theory"
+course_title: "Computability-and-Complexity-Theory"
 units: "12"
 level: "U"
 prerequisites: ["6.1200"]

--- a/universities/mit/cse/2025/S5/02.md
+++ b/universities/mit/cse/2025/S5/02.md
@@ -1,4 +1,5 @@
 ---
+
 country: "usa"
 university: "mit"
 branch: "cse"
@@ -10,7 +11,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1200"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S5/02.md
+++ b/universities/mit/cse/2025/S5/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 5
+course_code: "6.1400"
+course_title: "Computability and Complexity Theory"
+units: "12"
+level: "U"
+prerequisites: ["6.1200"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Computability and Complexity Theory explores the theoretical foundations of computer science, examining what problems can be computed and the resources required for computation. This course provides essential theoretical background for understanding the limits and capabilities of computational systems.
+
+## Learning Objectives
+
+- Master models of computation and formal languages
+- Understand computability theory and undecidability
+- Learn computational complexity classes and their relationships
+- Develop skills in mathematical proof and formal reasoning
+- Apply theoretical concepts to practical computational problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Formal Languages and Automata
+- Regular languages and finite automata
+- Context-free languages and pushdown automata
+- Parsing and language recognition
+
+**Weeks 3-4**: Turing Machines
+- Turing machine models and variants
+- Church-Turing thesis
+- Universal Turing machines
+
+**Weeks 5-6**: Computability Theory
+- Decidable and undecidable problems
+- Halting problem and reductions
+- Rice's theorem and applications
+
+**Weeks 7-8**: Computational Complexity
+- Time and space complexity classes
+- P vs NP problem and NP-completeness
+- Reduction techniques and completeness proofs
+
+**Weeks 9-10**: Advanced Complexity Classes
+- PSPACE and polynomial hierarchy
+- Approximation algorithms and complexity
+- Randomized algorithms and complexity
+
+**Weeks 11-12**: Applications and Current Research
+- Cryptographic complexity assumptions
+- Quantum computation models
+- Complexity in practice
+
+## Assessment & Workload
+
+12 units including theoretical problem sets, formal proofs, complexity analysis exercises, and examinations. Alternative to 6.1220[J] for theory requirement.
+
+## Recommended Texts & Resources
+
+- "Introduction to the Theory of Computation" by Michael Sipser
+- Computational complexity theory references
+- Mathematical proof and logic resources
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S6/01.md
+++ b/universities/mit/cse/2025/S6/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 6
+course_code: "6.3700"
+course_title: "Introduction to Probability"
+units: "12"
+level: "U"
+prerequisites: ["6.1200", "18.01"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Introduction to Probability provides the statistical foundation essential for computer science applications including machine learning, algorithms, and data analysis. This course covers probability theory, random variables, and statistical inference with applications to computing problems.
+
+## Learning Objectives
+
+- Master fundamental concepts of probability theory
+- Understand random variables and probability distributions
+- Learn statistical inference and hypothesis testing
+- Apply probabilistic reasoning to computer science problems
+- Develop skills in data analysis and interpretation
+
+## Syllabus Outline
+
+**Weeks 1-2**: Probability Fundamentals
+- Sample spaces, events, and probability axioms
+- Conditional probability and independence
+- Bayes' theorem and applications
+
+**Weeks 3-4**: Random Variables
+- Discrete and continuous random variables
+- Probability mass and density functions
+- Expectation and variance
+
+**Weeks 5-6**: Common Distributions
+- Binomial, Poisson, and geometric distributions
+- Normal, exponential, and uniform distributions
+- Applications to computer science problems
+
+**Weeks 7-8**: Multiple Random Variables
+- Joint and marginal distributions
+- Covariance and correlation
+- Conditional distributions and expectations
+
+**Weeks 9-10**: Limit Theorems
+- Law of large numbers
+- Central limit theorem
+- Applications to algorithm analysis
+
+**Weeks 11-12**: Statistical Applications
+- Parameter estimation and confidence intervals
+- Hypothesis testing and p-values
+- Applications to machine learning and data science
+
+## Assessment & Workload
+
+12 units including problem sets, statistical analysis projects, and examinations. Alternative options include 6.3800, 18.05, 18.06, or 18.C06[J].
+
+## Recommended Texts & Resources
+
+- Probability and statistics textbooks
+- Statistical software and computational tools
+- Real-world datasets for analysis
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S6/01.md
+++ b/universities/mit/cse/2025/S6/01.md
@@ -6,7 +6,7 @@ branch: "cse"
 version: "2025"
 semester: 6
 course_code: "6.3700"
-course_title: "Introduction to Probability"
+course_title: "Introduction-to-Probability"
 units: "12"
 level: "U"
 prerequisites: ["6.1200", "18.01"]

--- a/universities/mit/cse/2025/S6/01.md
+++ b/universities/mit/cse/2025/S6/01.md
@@ -1,4 +1,5 @@
 ---
+
 country: "usa"
 university: "mit"
 branch: "cse"
@@ -10,7 +11,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1200", "18.01"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S6/02.md
+++ b/universities/mit/cse/2025/S6/02.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1200", "6.1210", "18.06"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S6/02.md
+++ b/universities/mit/cse/2025/S6/02.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 6
 course_code: "6.4100"
-course_title: "Introduction to Machine Learning"
+course_title: "Introduction-to-Machine-Learning"
 units: "12"
 level: "U"
 prerequisites: ["6.1200", "6.1210", "18.06"]

--- a/universities/mit/cse/2025/S6/02.md
+++ b/universities/mit/cse/2025/S6/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 6
+course_code: "6.4100"
+course_title: "Introduction to Machine Learning"
+units: "12"
+level: "U"
+prerequisites: ["6.1200", "6.1210", "18.06"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Introduction to Machine Learning provides foundational knowledge in machine learning algorithms, statistical learning theory, and practical applications. This course serves as a Computer Science track elective, covering supervised and unsupervised learning methods with hands-on implementation experience.
+
+## Learning Objectives
+
+- Master fundamental machine learning algorithms and concepts
+- Understand statistical learning theory and model evaluation
+- Learn supervised and unsupervised learning techniques
+- Develop skills in feature engineering and model selection
+- Apply machine learning to real-world problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Introduction to Machine Learning
+- Supervised vs unsupervised learning
+- Bias-variance tradeoff
+- Cross-validation and model evaluation
+
+**Weeks 3-4**: Linear Models
+- Linear regression and regularization
+- Logistic regression and classification
+- Feature selection and engineering
+
+**Weeks 5-6**: Tree-based Methods
+- Decision trees and ensemble methods
+- Random forests and boosting
+- Handling overfitting and model complexity
+
+**Weeks 7-8**: Support Vector Machines
+- Maximum margin classifiers
+- Kernel methods and the kernel trick
+- Support vector regression
+
+**Weeks 9-10**: Unsupervised Learning
+- K-means clustering and hierarchical clustering
+- Principal component analysis
+- Dimensionality reduction techniques
+
+**Weeks 11-12**: Advanced Topics
+- Neural networks and deep learning basics
+- Reinforcement learning introduction
+- Ethics and fairness in machine learning
+
+## Assessment & Workload
+
+12 units including programming assignments, machine learning projects, data analysis exercises, and examinations. Represents one Computer Science track elective.
+
+## Recommended Texts & Resources
+
+- "The Elements of Statistical Learning" by Hastie, Tibshirani, and Friedman
+- Machine learning programming libraries and tools
+- Real-world datasets and case studies
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Track Information](https://catalog.mit.edu/degree-charts/electrical-engineering-computer-science-tracks/)

--- a/universities/mit/cse/2025/S7/01.md
+++ b/universities/mit/cse/2025/S7/01.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 7
 course_code: "6.5840"
-course_title: "Distributed Systems"
+course_title: "Distributed-Systems"
 units: "12"
 level: "U"
 prerequisites: ["6.1800"]

--- a/universities/mit/cse/2025/S7/01.md
+++ b/universities/mit/cse/2025/S7/01.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1800"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S7/01.md
+++ b/universities/mit/cse/2025/S7/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 7
+course_code: "6.5840"
+course_title: "Distributed Systems"
+units: "12"
+level: "U"
+prerequisites: ["6.1800"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Distributed Systems explores the design and implementation of systems that run across multiple connected computers. This advanced Computer Science track course covers consistency, fault tolerance, scalability, and the fundamental challenges in building reliable distributed applications.
+
+## Learning Objectives
+
+- Master distributed system design principles and trade-offs
+- Understand consistency models and consensus algorithms
+- Learn fault tolerance and replication strategies
+- Develop skills in distributed system implementation
+- Apply distributed computing concepts to real-world systems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Distributed System Fundamentals
+- System models and failure modes
+- Time and ordering in distributed systems
+- Communication protocols and messaging
+
+**Weeks 3-4**: Consistency and Replication
+- Consistency models and CAP theorem
+- Primary-backup and state machine replication
+- Quorum systems and eventual consistency
+
+**Weeks 5-6**: Consensus and Coordination
+- Consensus problem and impossibility results
+- Paxos and Raft consensus algorithms
+- Leader election and mutual exclusion
+
+**Weeks 7-8**: Distributed Storage Systems
+- Distributed file systems and databases
+- Sharding and partitioning strategies
+- MapReduce and distributed computing frameworks
+
+**Weeks 9-10**: Fault Tolerance
+- Byzantine fault tolerance
+- Failure detection and recovery
+- System reliability and availability
+
+**Weeks 11-12**: Modern Distributed Systems
+- Microservices and container orchestration
+- Blockchain and distributed ledgers
+- Cloud computing and serverless architectures
+
+## Assessment & Workload
+
+12 units including distributed system implementations, research paper analysis, and examinations. Represents one Computer Science track elective with significant practical component.
+
+## Recommended Texts & Resources
+
+- "Designing Data-Intensive Applications" by Martin Kleppmann
+- Distributed systems research papers and case studies
+- Cloud platforms and distributed system tools
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Track Information](https://catalog.mit.edu/degree-charts/electrical-engineering-computer-science-tracks/)

--- a/universities/mit/cse/2025/S7/02.md
+++ b/universities/mit/cse/2025/S7/02.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 7
 course_code: "6.4400"
-course_title: "Computer Graphics"
+course_title: "Computer-Graphics"
 units: "12"
 level: "U"
 prerequisites: ["6.1210", "18.06"]

--- a/universities/mit/cse/2025/S7/02.md
+++ b/universities/mit/cse/2025/S7/02.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1210", "18.06"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S7/02.md
+++ b/universities/mit/cse/2025/S7/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 7
+course_code: "6.4400"
+course_title: "Computer Graphics"
+units: "12"
+level: "U"
+prerequisites: ["6.1210", "18.06"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Computer Graphics covers the mathematical foundations and practical techniques for creating, manipulating, and rendering digital images and 3D scenes. This Computer Science track course combines theoretical concepts with hands-on programming to develop skills in visual computing and interactive graphics applications.
+
+## Learning Objectives
+
+- Master fundamental concepts in 2D and 3D computer graphics
+- Understand geometric transformations and coordinate systems
+- Learn rendering algorithms and graphics pipeline concepts
+- Develop skills in graphics programming and shader development
+- Apply computer graphics techniques to create interactive applications
+
+## Syllabus Outline
+
+**Weeks 1-2**: Graphics Fundamentals
+- Coordinate systems and transformations
+- 2D graphics primitives and rasterization
+- Color models and digital image representation
+
+**Weeks 3-4**: 3D Geometry and Transformations
+- 3D coordinate systems and homogeneous coordinates
+- Rotation, scaling, and translation matrices
+- Viewing transformations and projections
+
+**Weeks 5-6**: Rendering Pipeline
+- Graphics hardware and GPU architecture
+- Vertex and fragment processing
+- Clipping, culling, and depth testing
+
+**Weeks 7-8**: Illumination and Shading
+- Light sources and material properties
+- Phong and Blinn-Phong shading models
+- Texture mapping and filtering
+
+**Weeks 9-10**: Advanced Rendering Techniques
+- Ray tracing and global illumination
+- Shadows and reflections
+- Anti-aliasing and sampling techniques
+
+**Weeks 11-12**: Interactive Graphics and Applications
+- User interaction and animation
+- Collision detection and physics simulation
+- Real-time rendering optimization
+
+## Assessment & Workload
+
+12 units including graphics programming assignments, rendering projects, and examinations. Represents one Computer Science track elective with substantial programming component.
+
+## Recommended Texts & Resources
+
+- "Computer Graphics: Principles and Practice" by Foley et al.
+- Graphics programming libraries and development environments
+- 3D modeling and animation software
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Track Information](https://catalog.mit.edu/degree-charts/electrical-engineering-computer-science-tracks/)

--- a/universities/mit/cse/2025/S8/01.md
+++ b/universities/mit/cse/2025/S8/01.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["6.1020"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/S8/01.md
+++ b/universities/mit/cse/2025/S8/01.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 8
+course_code: "6.1040"
+course_title: "Software Design for User Interfaces"
+units: "12"
+level: "U"
+prerequisites: ["6.1020"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Software Design for User Interfaces focuses on the design and implementation of interactive software systems with emphasis on user experience and interface design principles. This capstone-level course integrates software engineering with human-computer interaction concepts to create effective user-facing applications.
+
+## Learning Objectives
+
+- Master user interface design principles and usability concepts
+- Understand human-computer interaction theory and practice
+- Learn front-end development technologies and frameworks
+- Develop skills in user experience research and testing
+- Apply design thinking to create effective software interfaces
+
+## Syllabus Outline
+
+**Weeks 1-2**: UI/UX Design Fundamentals
+- Design thinking and user-centered design
+- Visual design principles and typography
+- Information architecture and wireframing
+
+**Weeks 3-4**: Human-Computer Interaction
+- Cognitive models of user behavior
+- Usability principles and guidelines
+- Accessibility and inclusive design
+
+**Weeks 5-6**: Front-end Development
+- Web technologies: HTML, CSS, JavaScript
+- Modern front-end frameworks and libraries
+- Responsive design and mobile interfaces
+
+**Weeks 7-8**: User Research and Testing
+- User research methods and techniques
+- Prototyping and iterative design
+- Usability testing and evaluation
+
+**Weeks 9-10**: Advanced Interface Concepts
+- Interactive visualization and data presentation
+- Voice interfaces and natural interaction
+- Virtual and augmented reality interfaces
+
+**Weeks 11-12**: Capstone Project
+- End-to-end interface design and development
+- User testing and iteration
+- Project presentation and evaluation
+
+## Assessment & Workload
+
+12 units including design assignments, prototyping projects, user research exercises, and a comprehensive capstone project. Satisfies advanced degree requirements.
+
+## Recommended Texts & Resources
+
+- "The Design of Everyday Things" by Don Norman
+- UI/UX design tools and prototyping software
+- User research and testing platforms
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Subject Listings](https://catalog.mit.edu/subjects/6/)

--- a/universities/mit/cse/2025/S8/01.md
+++ b/universities/mit/cse/2025/S8/01.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 8
 course_code: "6.1040"
-course_title: "Software Design for User Interfaces"
+course_title: "Software-Design-for-User-Interfaces"
 units: "12"
 level: "U"
 prerequisites: ["6.1020"]

--- a/universities/mit/cse/2025/S8/02.md
+++ b/universities/mit/cse/2025/S8/02.md
@@ -1,0 +1,73 @@
+---
+country: "usa"
+university: "mit"
+branch: "cse"
+version: "2025"
+semester: 8
+course_code: "6.THESIS"
+course_title: "Undergraduate Thesis in Computer Science"
+units: "12"
+level: "U"
+prerequisites: ["Advanced standing"]
+language: "english"
+contributor: "@amp"
+---
+
+## Overview
+
+Undergraduate Thesis in Computer Science provides an opportunity for advanced students to conduct independent research under faculty supervision. This capstone experience allows students to apply their accumulated knowledge to an original research problem in computer science, preparing them for graduate study or professional research careers.
+
+## Learning Objectives
+
+- Develop expertise in a specialized area of computer science
+- Master research methodology and scientific communication
+- Learn project management and independent work skills
+- Understand the research process from problem formulation to publication
+- Apply advanced computer science concepts to solve original problems
+
+## Syllabus Outline
+
+**Weeks 1-2**: Research Problem Definition
+- Literature review and problem identification
+- Research methodology and experimental design
+- Thesis proposal development
+
+**Weeks 3-4**: Background Research
+- Comprehensive literature survey
+- Technical background development
+- Related work analysis
+
+**Weeks 5-6**: System Design and Planning
+- System architecture and implementation planning
+- Resource allocation and timeline development
+- Risk assessment and mitigation strategies
+
+**Weeks 7-8**: Implementation Phase
+- Core system development
+- Algorithm implementation and optimization
+- Data collection and experimental setup
+
+**Weeks 9-10**: Evaluation and Analysis
+- Experimental evaluation and testing
+- Performance analysis and benchmarking
+- Results interpretation and validation
+
+**Weeks 11-12**: Thesis Writing and Presentation
+- Thesis document preparation
+- Oral presentation development
+- Defense preparation and final submission
+
+## Assessment & Workload
+
+12 units of independent research including thesis proposal, implementation work, experimental evaluation, written thesis, and oral defense. Satisfies advanced undergraduate requirement.
+
+## Recommended Texts & Resources
+
+- Research methodology and scientific writing guides
+- Specialized literature in chosen research area
+- Research tools and development environments
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT UROP and SuperUROP Programs](https://urop.mit.edu/)

--- a/universities/mit/cse/2025/S8/02.md
+++ b/universities/mit/cse/2025/S8/02.md
@@ -5,7 +5,7 @@ branch: "cse"
 version: "2025"
 semester: 8
 course_code: "6.THESIS"
-course_title: "Undergraduate Thesis in Computer Science"
+course_title: "Undergraduate-Thesis-in-Computer-Science"
 units: "12"
 level: "U"
 prerequisites: ["Advanced standing"]

--- a/universities/mit/cse/2025/S8/02.md
+++ b/universities/mit/cse/2025/S8/02.md
@@ -10,7 +10,7 @@ units: "12"
 level: "U"
 prerequisites: ["Advanced standing"]
 language: "english"
-contributor: "@amp"
+contributor: "@deepusnath"
 ---
 
 ## Overview

--- a/universities/mit/cse/2025/overview.md
+++ b/universities/mit/cse/2025/overview.md
@@ -1,0 +1,50 @@
+# MIT Computer Science and Engineering (Course 6-3) - 2025
+
+## Overview
+
+MIT's Course 6-3 (Computer Science and Engineering) is a comprehensive undergraduate program that combines theoretical foundations with practical skills in computer science. This major covers algorithms and theory, software engineering, programming languages, computer systems, human-computer interaction, graphics, and artificial intelligence and machine learning.
+
+The program follows MIT's distinctive approach to technical education, emphasizing both depth and breadth. Students complete the General Institute Requirements (GIRs) alongside specialized coursework that progresses from fundamental programming concepts to advanced topics in computer science.
+
+## Degree Requirements Highlights
+
+### Core Subjects (171-174 units)
+- **Programming Foundation**: 6.100A/L (Introduction to CS Programming), 6.1010 (Fundamentals of Programming), 6.1020 (Software Construction)
+- **Mathematics**: 6.1200[J] (Mathematics for Computer Science), 6.1210 (Introduction to Algorithms)
+- **Theory**: 6.1400[J] (Computability and Complexity Theory) or 6.1220[J] (Design and Analysis of Algorithms)
+- **Systems**: 6.1800 (Computer Systems Engineering), 6.1903 (Low-level Programming), 6.1910 (Computation Structures)
+- **Statistics/Math**: Choice of 6.3700, 6.3800, 18.05, 18.06, or 18.C06[J]
+
+### Track Requirements
+- Two subjects from a Computer Science track
+- Two subjects from CS, AI + Decision Making, or Electrical Engineering tracks
+- One subject satisfying degree requirements in 6-2, 6-3, 6-4, or 18
+
+### General Institute Requirements (GIRs)
+- Science Requirement (6 subjects)
+- HASS Requirement (8 subjects, including communication-intensive subjects)
+- REST Requirement (2 subjects)
+- Laboratory Requirement (satisfied by 6.1010)
+- Physical Education and Swimming
+
+## Subject Numbering Notes
+
+As of 2022, MIT EECS has undergone significant curriculum restructuring with new subject numbering:
+- 6.100A/L replaces 6.0001
+- 6.1010 consolidates multiple programming subjects
+- 6.1200[J] is cross-listed with 18.062[J]
+- Many subjects have been renumbered in the 6.1xxx series
+
+## Course Tracks
+
+Students can specialize through various tracks including:
+- **Computer Science tracks**: Systems, Theory, AI/ML, Programming Languages, Graphics/HCI
+- **AI + Decision Making tracks**: Machine Learning, Robotics, Natural Language Processing
+- **Electrical Engineering tracks**: Circuits, Signal Processing, Communications
+
+## References
+
+- [MIT Course 6-3 Degree Chart](https://catalog.mit.edu/degree-charts/computer-science-engineering-course-6-3/)
+- [MIT EECS Curriculum Hub](https://www.eecs.mit.edu/academics/undergraduate-programs/curriculum/6-3-computer-science-and-engineering/)
+- [MIT Subject Listings](https://catalog.mit.edu/subjects/6/)
+- [MIT EECS Track Information](https://catalog.mit.edu/degree-charts/electrical-engineering-computer-science-tracks/)


### PR DESCRIPTION
## What I Added
- Added MIT 6.3 Computer Science syllabus for 2025 semester [1-8]
- Created 16 course files following the markdown structure
- All files include YAML frontmatter