### PR TITLE
Add Syllabus Folder Structure for University of Toronto

### DIFF
--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/01.md
@@ -1,0 +1,3 @@
+# Accounting and Finance
+
+Details about Accounting and Finance program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/01.md
@@ -1,3 +1,0 @@
-# Accounting and Finance
-
-Details about Accounting and Finance program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Accounting_and_Finance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/01.md
@@ -1,0 +1,3 @@
+# Adult Education and Community Development
+
+Details about Adult Education and Community Development program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/01.md
@@ -1,3 +1,0 @@
-# Adult Education and Community Development
-
-Details about Adult Education and Community Development program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Adult_Education_and_Community_Development/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/01.md
@@ -1,0 +1,3 @@
+# Aerospace Science and Engineering
+
+Details about Aerospace Science and Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/01.md
@@ -1,3 +1,0 @@
-# Aerospace Science and Engineering
-
-Details about Aerospace Science and Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Aerospace_Science_and_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/01.md
@@ -1,3 +1,0 @@
-# Anthropology
-
-Details about Anthropology program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/01.md
@@ -1,0 +1,3 @@
+# Anthropology
+
+Details about Anthropology program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Anthropology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/01.md
@@ -1,0 +1,3 @@
+# Applied Computing
+
+Details about Applied Computing program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/01.md
@@ -1,3 +1,0 @@
-# Applied Computing
-
-Details about Applied Computing program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Applied_Computing/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/01.md
@@ -1,3 +1,0 @@
-# Architecture
-
-Details about Architecture program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/01.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Details about Architecture program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Architecture/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/01.md
@@ -1,3 +1,0 @@
-# Art History
-
-Details about Art History program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/01.md
@@ -1,0 +1,3 @@
+# Art History
+
+Details about Art History program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Art_History/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/01.md
@@ -1,0 +1,3 @@
+# Astronomy and Astrophysics
+
+Details about Astronomy and Astrophysics program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/01.md
@@ -1,3 +1,0 @@
-# Astronomy and Astrophysics
-
-Details about Astronomy and Astrophysics program.

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/A/Astronomy_and_Astrophysics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/01.md
@@ -1,3 +1,0 @@
-# Biochemistry
-
-Details about Biochemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/01.md
@@ -1,0 +1,3 @@
+# Biochemistry
+
+Details about Biochemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biochemistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/01.md
@@ -1,3 +1,0 @@
-# Bioethics
-
-Details about Bioethics program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/01.md
@@ -1,0 +1,3 @@
+# Bioethics
+
+Details about Bioethics program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Bioethics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/01.md
@@ -1,0 +1,3 @@
+# Biomedical Communications
+
+Details about Biomedical Communications program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/01.md
@@ -1,3 +1,0 @@
-# Biomedical Communications
-
-Details about Biomedical Communications program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Communications/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/01.md
@@ -1,0 +1,3 @@
+# Biomedical Engineering
+
+Details about Biomedical Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/01.md
@@ -1,3 +1,0 @@
-# Biomedical Engineering
-
-Details about Biomedical Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biomedical_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/01.md
@@ -1,3 +1,0 @@
-# Biotechnology
-
-Details about Biotechnology program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/01.md
@@ -1,0 +1,3 @@
+# Biotechnology
+
+Details about Biotechnology program.

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/B/Biotechnology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/01.md
@@ -1,3 +1,0 @@
-# Cell and Systems Biology
-
-Details about Cell and Systems Biology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/01.md
@@ -1,0 +1,3 @@
+# Cell and Systems Biology
+
+Details about Cell and Systems Biology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cell_and_Systems_Biology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/01.md
@@ -1,3 +1,0 @@
-# Chemical Engineering and Applied Chemistry
-
-Details about Chemical Engineering and Applied Chemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/01.md
@@ -1,0 +1,3 @@
+# Chemical Engineering and Applied Chemistry
+
+Details about Chemical Engineering and Applied Chemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemical_Engineering_and_Applied_Chemistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/01.md
@@ -1,0 +1,3 @@
+# Chemistry
+
+Details about Chemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/01.md
@@ -1,3 +1,0 @@
-# Chemistry
-
-Details about Chemistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Chemistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/01.md
@@ -1,3 +1,0 @@
-# Child Study and Education
-
-Details about Child Study and Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/01.md
@@ -1,0 +1,3 @@
+# Child Study and Education
+
+Details about Child Study and Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Child_Study_and_Education/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/01.md
@@ -1,0 +1,3 @@
+# Cinema Studies
+
+Details about Cinema Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/01.md
@@ -1,3 +1,0 @@
-# Cinema Studies
-
-Details about Cinema Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cinema_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/01.md
@@ -1,3 +1,0 @@
-# Cities Engineering and Management
-
-Details about Cities Engineering and Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/01.md
@@ -1,0 +1,3 @@
+# Cities Engineering and Management
+
+Details about Cities Engineering and Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Cities_Engineering_and_Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/01.md
@@ -1,0 +1,3 @@
+# Civil Engineering
+
+Details about Civil Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/01.md
@@ -1,3 +1,0 @@
-# Civil Engineering
-
-Details about Civil Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Civil_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/01.md
@@ -1,3 +1,0 @@
-# Classics
-
-Details about Classics program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/01.md
@@ -1,0 +1,3 @@
+# Classics
+
+Details about Classics program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Classics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/01.md
@@ -1,0 +1,3 @@
+# Clinical Psychology
+
+Details about Clinical Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/01.md
@@ -1,3 +1,0 @@
-# Clinical Psychology
-
-Details about Clinical Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/01.md
@@ -1,0 +1,3 @@
+# Clinical and Counselling Psychology
+
+Details about Clinical and Counselling Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/01.md
@@ -1,3 +1,0 @@
-# Clinical and Counselling Psychology
-
-Details about Clinical and Counselling Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Clinical_and_Counselling_Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/01.md
@@ -1,0 +1,3 @@
+# Community Health
+
+Details about Community Health program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/01.md
@@ -1,3 +1,0 @@
-# Community Health
-
-Details about Community Health program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Community_Health/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/01.md
@@ -1,3 +1,0 @@
-# Comparative Literature
-
-Details about Comparative Literature program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/01.md
@@ -1,0 +1,3 @@
+# Comparative Literature
+
+Details about Comparative Literature program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Comparative_Literature/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/01.md
@@ -1,0 +1,3 @@
+# Computer Science
+
+Details about Computer Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/01.md
@@ -1,3 +1,0 @@
-# Computer Science
-
-Details about Computer Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Computer_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/01.md
@@ -1,0 +1,3 @@
+# Counselling Psychology
+
+Details about Counselling Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/01.md
@@ -1,3 +1,0 @@
-# Counselling Psychology
-
-Details about Counselling Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/01.md
@@ -1,0 +1,3 @@
+# Counselling and Clinical Psychology
+
+Details about Counselling and Clinical Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/01.md
@@ -1,3 +1,0 @@
-# Counselling and Clinical Psychology
-
-Details about Counselling and Clinical Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Counselling_and_Clinical_Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/01.md
@@ -1,0 +1,3 @@
+# Criminology and Sociolegal Studies
+
+Details about Criminology and Sociolegal Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/01.md
@@ -1,3 +1,0 @@
-# Criminology and Sociolegal Studies
-
-Details about Criminology and Sociolegal Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Criminology_and_Sociolegal_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/01.md
@@ -1,0 +1,3 @@
+# Curriculum and Pedagogy
+
+Details about Curriculum and Pedagogy program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/01.md
@@ -1,3 +1,0 @@
-# Curriculum and Pedagogy
-
-Details about Curriculum and Pedagogy program.

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/C/Curriculum_and_Pedagogy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/01.md
@@ -1,0 +1,3 @@
+# Dentistry
+
+Details about Dentistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/01.md
@@ -1,3 +1,0 @@
-# Dentistry
-
-Details about Dentistry program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Dentistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/01.md
@@ -1,3 +1,0 @@
-# Developmental Psychology and Education
-
-Details about Developmental Psychology and Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/01.md
@@ -1,0 +1,3 @@
+# Developmental Psychology and Education
+
+Details about Developmental Psychology and Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Developmental_Psychology_and_Education/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/01.md
@@ -1,3 +1,0 @@
-# Drama Theatre and Performance Studies
-
-Details about Drama Theatre and Performance Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/01.md
@@ -1,0 +1,3 @@
+# Drama Theatre and Performance Studies
+
+Details about Drama Theatre and Performance Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/D/Drama_Theatre_and_Performance_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/01.md
@@ -1,0 +1,3 @@
+# Earth Sciences
+
+Details about Earth Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/01.md
@@ -1,3 +1,0 @@
-# Earth Sciences
-
-Details about Earth Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Earth_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/01.md
@@ -1,0 +1,3 @@
+# East Asian Studies
+
+Details about East Asian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/01.md
@@ -1,3 +1,0 @@
-# East Asian Studies
-
-Details about East Asian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/East_Asian_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/01.md
@@ -1,3 +1,0 @@
-# Ecology and Evolutionary Biology
-
-Details about Ecology and Evolutionary Biology program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/01.md
@@ -1,0 +1,3 @@
+# Ecology and Evolutionary Biology
+
+Details about Ecology and Evolutionary Biology program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Ecology_and_Evolutionary_Biology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/01.md
@@ -1,3 +1,0 @@
-# Economics
-
-Details about Economics program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/01.md
@@ -1,0 +1,3 @@
+# Economics
+
+Details about Economics program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Economics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/01.md
@@ -1,3 +1,0 @@
-# Educational Leadership and Policy
-
-Details about Educational Leadership and Policy program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/01.md
@@ -1,0 +1,3 @@
+# Educational Leadership and Policy
+
+Details about Educational Leadership and Policy program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Educational_Leadership_and_Policy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/01.md
@@ -1,0 +1,3 @@
+# Electrical and Computer Engineering
+
+Details about Electrical and Computer Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/01.md
@@ -1,3 +1,0 @@
-# Electrical and Computer Engineering
-
-Details about Electrical and Computer Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Electrical_and_Computer_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/01.md
@@ -1,0 +1,3 @@
+# English
+
+Details about English program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/01.md
@@ -1,3 +1,0 @@
-# English
-
-Details about English program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/English/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/01.md
@@ -1,3 +1,0 @@
-# Environment and Sustainability
-
-Details about Environment and Sustainability program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/01.md
@@ -1,0 +1,3 @@
+# Environment and Sustainability
+
+Details about Environment and Sustainability program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environment_and_Sustainability/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/01.md
@@ -1,0 +1,3 @@
+# Environmental Science
+
+Details about Environmental Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/01.md
@@ -1,3 +1,0 @@
-# Environmental Science
-
-Details about Environmental Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/Environmental_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/01.md
@@ -1,3 +1,0 @@
-# European and Eurasian Studies
-
-Details about European and Eurasian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/01.md
@@ -1,0 +1,3 @@
+# European and Eurasian Studies
+
+Details about European and Eurasian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/E/European_and_Eurasian_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/01.md
@@ -1,3 +1,0 @@
-# Financial Economics
-
-Details about Financial Economics program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/01.md
@@ -1,0 +1,3 @@
+# Financial Economics
+
+Details about Financial Economics program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Economics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/01.md
@@ -1,3 +1,0 @@
-# Financial Insurance
-
-Details about Financial Insurance program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/01.md
@@ -1,0 +1,3 @@
+# Financial Insurance
+
+Details about Financial Insurance program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Insurance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/01.md
@@ -1,3 +1,0 @@
-# Financial Risk Management
-
-Details about Financial Risk Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/01.md
@@ -1,0 +1,3 @@
+# Financial Risk Management
+
+Details about Financial Risk Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Financial_Risk_Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/01.md
@@ -1,3 +1,0 @@
-# Forensic Accounting
-
-Details about Forensic Accounting program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/01.md
@@ -1,0 +1,3 @@
+# Forensic Accounting
+
+Details about Forensic Accounting program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forensic_Accounting/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/01.md
@@ -1,3 +1,0 @@
-# Forest Conservation
-
-Details about Forest Conservation program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/01.md
@@ -1,0 +1,3 @@
+# Forest Conservation
+
+Details about Forest Conservation program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forest_Conservation/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/01.md
@@ -1,3 +1,0 @@
-# Forestry
-
-Details about Forestry program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/01.md
@@ -1,0 +1,3 @@
+# Forestry
+
+Details about Forestry program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/Forestry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/01.md
@@ -1,3 +1,0 @@
-# French Language and Literature
-
-Details about French Language and Literature program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/01.md
@@ -1,0 +1,3 @@
+# French Language and Literature
+
+Details about French Language and Literature program.

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/F/French_Language_and_Literature/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/01.md
@@ -1,3 +1,0 @@
-# Genetic Counselling
-
-Details about Genetic Counselling program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/01.md
@@ -1,0 +1,3 @@
+# Genetic Counselling
+
+Details about Genetic Counselling program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Genetic_Counselling/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/01.md
@@ -1,3 +1,0 @@
-# Geography
-
-Details about Geography program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/01.md
@@ -1,0 +1,3 @@
+# Geography
+
+Details about Geography program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Geography/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/01.md
@@ -1,0 +1,3 @@
+# Germanic Languages and Literatures
+
+Details about Germanic Languages and Literatures program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/01.md
@@ -1,3 +1,0 @@
-# Germanic Languages and Literatures
-
-Details about Germanic Languages and Literatures program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Languages_and_Literatures/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/01.md
@@ -1,3 +1,0 @@
-# Germanic Literature Culture and Theory
-
-Details about Germanic Literature Culture and Theory program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/01.md
@@ -1,0 +1,3 @@
+# Germanic Literature Culture and Theory
+
+Details about Germanic Literature Culture and Theory program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Germanic_Literature_Culture_and_Theory/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/01.md
@@ -1,0 +1,3 @@
+# Global Affairs
+
+Details about Global Affairs program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/01.md
@@ -1,3 +1,0 @@
-# Global Affairs
-
-Details about Global Affairs program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Affairs/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/01.md
@@ -1,0 +1,3 @@
+# Global Professional Law
+
+Details about Global Professional Law program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/01.md
@@ -1,3 +1,0 @@
-# Global Professional Law
-
-Details about Global Professional Law program.

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/G/Global_Professional_Law/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/01.md
@@ -1,3 +1,0 @@
-# Health Administration
-
-Details about Health Administration program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/01.md
@@ -1,0 +1,3 @@
+# Health Administration
+
+Details about Health Administration program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Administration/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/01.md
@@ -1,0 +1,3 @@
+# Health Informatics
+
+Details about Health Informatics program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/01.md
@@ -1,3 +1,0 @@
-# Health Informatics
-
-Details about Health Informatics program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Informatics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/01.md
@@ -1,3 +1,0 @@
-# Health Policy Management and Evaluation
-
-Details about Health Policy Management and Evaluation program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/01.md
@@ -1,0 +1,3 @@
+# Health Policy Management and Evaluation
+
+Details about Health Policy Management and Evaluation program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Health_Policy_Management_and_Evaluation/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/01.md
@@ -1,0 +1,3 @@
+# Higher Education
+
+Details about Higher Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/01.md
@@ -1,3 +1,0 @@
-# Higher Education
-
-Details about Higher Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/Higher_Education/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/01.md
@@ -1,3 +1,0 @@
-# History
-
-Details about History program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/01.md
@@ -1,0 +1,3 @@
+# History
+
+Details about History program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/01.md
@@ -1,0 +1,3 @@
+# History and Philosophy of Science and Technology
+
+Details about History and Philosophy of Science and Technology program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/01.md
@@ -1,3 +1,0 @@
-# History and Philosophy of Science and Technology
-
-Details about History and Philosophy of Science and Technology program.

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/H/History_and_Philosophy_of_Science_and_Technology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/01.md
@@ -1,3 +1,0 @@
-# Immunology
-
-Details about Immunology program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/01.md
@@ -1,0 +1,3 @@
+# Immunology
+
+Details about Immunology program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Immunology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/01.md
@@ -1,0 +1,3 @@
+# Industrial Relations and Human Resources
+
+Details about Industrial Relations and Human Resources program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/01.md
@@ -1,3 +1,0 @@
-# Industrial Relations and Human Resources
-
-Details about Industrial Relations and Human Resources program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Industrial_Relations_and_Human_Resources/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/01.md
@@ -1,3 +1,0 @@
-# Information
-
-Details about Information program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/01.md
@@ -1,0 +1,3 @@
+# Information
+
+Details about Information program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Information/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/01.md
@@ -1,3 +1,0 @@
-# Italian Studies
-
-Details about Italian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/01.md
@@ -1,0 +1,3 @@
+# Italian Studies
+
+Details about Italian Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/I/Italian_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/01.md
@@ -1,0 +1,3 @@
+# Kinesiology
+
+Details about Kinesiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/01.md
@@ -1,3 +1,0 @@
-# Kinesiology
-
-Details about Kinesiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/K/Kinesiology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/01.md
@@ -1,3 +1,0 @@
-# Laboratory Medicine
-
-Details about Laboratory Medicine program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/01.md
@@ -1,0 +1,3 @@
+# Laboratory Medicine
+
+Details about Laboratory Medicine program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/01.md
@@ -1,3 +1,0 @@
-# Laboratory Medicine and Pathobiology
-
-Details about Laboratory Medicine and Pathobiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/01.md
@@ -1,0 +1,3 @@
+# Laboratory Medicine and Pathobiology
+
+Details about Laboratory Medicine and Pathobiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Laboratory_Medicine_and_Pathobiology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/01.md
@@ -1,3 +1,0 @@
-# Landscape Architecture
-
-Details about Landscape Architecture program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/01.md
@@ -1,0 +1,3 @@
+# Landscape Architecture
+
+Details about Landscape Architecture program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Landscape_Architecture/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/01.md
@@ -1,3 +1,0 @@
-# Language and Literacies Education
-
-Details about Language and Literacies Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/01.md
@@ -1,0 +1,3 @@
+# Language and Literacies Education
+
+Details about Language and Literacies Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Language_and_Literacies_Education/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/01.md
@@ -1,3 +1,0 @@
-# Law
-
-Details about Law program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/01.md
@@ -1,0 +1,3 @@
+# Law
+
+Details about Law program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Law/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/01.md
@@ -1,0 +1,3 @@
+# Linguistics
+
+Details about Linguistics program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/01.md
@@ -1,3 +1,0 @@
-# Linguistics
-
-Details about Linguistics program.

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/L/Linguistics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/01.md
@@ -1,3 +1,0 @@
-# Management
-
-Details about Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/01.md
@@ -1,0 +1,3 @@
+# Management
+
+Details about Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/01.md
@@ -1,3 +1,0 @@
-# Management Analytics
-
-Details about Management Analytics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/01.md
@@ -1,0 +1,3 @@
+# Management Analytics
+
+Details about Management Analytics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Analytics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/01.md
@@ -1,0 +1,3 @@
+# Management Tri-Campus
+
+Details about Management Tri-Campus program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/01.md
@@ -1,3 +1,0 @@
-# Management Tri-Campus
-
-Details about Management Tri-Campus program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_Tri-Campus/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/01.md
@@ -1,3 +1,0 @@
-# Management and Professional Accounting
-
-Details about Management and Professional Accounting program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/01.md
@@ -1,0 +1,3 @@
+# Management and Professional Accounting
+
+Details about Management and Professional Accounting program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_and_Professional_Accounting/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/01.md
@@ -1,3 +1,0 @@
-# Management of Innovation
-
-Details about Management of Innovation program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/01.md
@@ -1,0 +1,3 @@
+# Management of Innovation
+
+Details about Management of Innovation program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Management_of_Innovation/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/01.md
@@ -1,0 +1,3 @@
+# Materials Science and Engineering
+
+Details about Materials Science and Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/01.md
@@ -1,3 +1,0 @@
-# Materials Science and Engineering
-
-Details about Materials Science and Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Materials_Science_and_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/01.md
@@ -1,0 +1,3 @@
+# Mathematical Finance
+
+Details about Mathematical Finance program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/01.md
@@ -1,3 +1,0 @@
-# Mathematical Finance
-
-Details about Mathematical Finance program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematical_Finance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/01.md
@@ -1,0 +1,3 @@
+# Mathematics
+
+Details about Mathematics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/01.md
@@ -1,3 +1,0 @@
-# Mathematics
-
-Details about Mathematics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mathematics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/01.md
@@ -1,3 +1,0 @@
-# Mechanical and Industrial Engineering
-
-Details about Mechanical and Industrial Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/01.md
@@ -1,0 +1,3 @@
+# Mechanical and Industrial Engineering
+
+Details about Mechanical and Industrial Engineering program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Mechanical_and_Industrial_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/01.md
@@ -1,3 +1,0 @@
-# Medical Biophysics
-
-Details about Medical Biophysics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/01.md
@@ -1,0 +1,3 @@
+# Medical Biophysics
+
+Details about Medical Biophysics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Biophysics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/01.md
@@ -1,0 +1,3 @@
+# Medical Genomics
+
+Details about Medical Genomics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/01.md
@@ -1,3 +1,0 @@
-# Medical Genomics
-
-Details about Medical Genomics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Genomics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/01.md
@@ -1,3 +1,0 @@
-# Medical Physiology
-
-Details about Medical Physiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/01.md
@@ -1,0 +1,3 @@
+# Medical Physiology
+
+Details about Medical Physiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Physiology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/01.md
@@ -1,3 +1,0 @@
-# Medical Science
-
-Details about Medical Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/01.md
@@ -1,0 +1,3 @@
+# Medical Science
+
+Details about Medical Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medical_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/01.md
@@ -1,3 +1,0 @@
-# Medieval Studies
-
-Details about Medieval Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/01.md
@@ -1,0 +1,3 @@
+# Medieval Studies
+
+Details about Medieval Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Medieval_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/01.md
@@ -1,3 +1,0 @@
-# Molecular Genetics
-
-Details about Molecular Genetics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/01.md
@@ -1,0 +1,3 @@
+# Molecular Genetics
+
+Details about Molecular Genetics program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Molecular_Genetics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/01.md
@@ -1,0 +1,3 @@
+# Museum Studies
+
+Details about Museum Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/01.md
@@ -1,3 +1,0 @@
-# Museum Studies
-
-Details about Museum Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Museum_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/01.md
@@ -1,0 +1,3 @@
+# Music
+
+Details about Music program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/01.md
@@ -1,3 +1,0 @@
-# Music
-
-Details about Music program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/01.md
@@ -1,0 +1,3 @@
+# Music Performance
+
+Details about Music Performance program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/01.md
@@ -1,3 +1,0 @@
-# Music Performance
-
-Details about Music Performance program.

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/M/Music_Performance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/01.md
@@ -1,3 +1,0 @@
-# Near and Middle Eastern Civilizations
-
-Details about Near and Middle Eastern Civilizations program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/01.md
@@ -1,0 +1,3 @@
+# Near and Middle Eastern Civilizations
+
+Details about Near and Middle Eastern Civilizations program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Near_and_Middle_Eastern_Civilizations/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/01.md
@@ -1,3 +1,0 @@
-# Nursing Science
-
-Details about Nursing Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/01.md
@@ -1,0 +1,3 @@
+# Nursing Science
+
+Details about Nursing Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nursing_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/01.md
@@ -1,0 +1,3 @@
+# Nutritional Sciences
+
+Details about Nutritional Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/01.md
@@ -1,3 +1,0 @@
-# Nutritional Sciences
-
-Details about Nutritional Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/N/Nutritional_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/01.md
@@ -1,0 +1,3 @@
+# Occupational Therapy
+
+Details about Occupational Therapy program.

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/01.md
@@ -1,3 +1,0 @@
-# Occupational Therapy
-
-Details about Occupational Therapy program.

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/O/Occupational_Therapy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/01.md
@@ -1,0 +1,3 @@
+# Pharmaceutical Sciences
+
+Details about Pharmaceutical Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/01.md
@@ -1,3 +1,0 @@
-# Pharmaceutical Sciences
-
-Details about Pharmaceutical Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmaceutical_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/01.md
@@ -1,0 +1,3 @@
+# Pharmacology
+
+Details about Pharmacology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/01.md
@@ -1,3 +1,0 @@
-# Pharmacology
-
-Details about Pharmacology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/01.md
@@ -1,0 +1,3 @@
+# Pharmacy
+
+Details about Pharmacy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/01.md
@@ -1,3 +1,0 @@
-# Pharmacy
-
-Details about Pharmacy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Pharmacy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/01.md
@@ -1,3 +1,0 @@
-# Philosophy
-
-Details about Philosophy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/01.md
@@ -1,0 +1,3 @@
+# Philosophy
+
+Details about Philosophy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Philosophy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/01.md
@@ -1,0 +1,3 @@
+# Physical Therapy
+
+Details about Physical Therapy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/01.md
@@ -1,3 +1,0 @@
-# Physical Therapy
-
-Details about Physical Therapy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physical_Therapy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/01.md
@@ -1,0 +1,3 @@
+# Physics
+
+Details about Physics program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/01.md
@@ -1,3 +1,0 @@
-# Physics
-
-Details about Physics program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/01.md
@@ -1,0 +1,3 @@
+# Physiology
+
+Details about Physiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/01.md
@@ -1,3 +1,0 @@
-# Physiology
-
-Details about Physiology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Physiology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/01.md
@@ -1,3 +1,0 @@
-# Planning
-
-Details about Planning program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/01.md
@@ -1,0 +1,3 @@
+# Planning
+
+Details about Planning program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Planning/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/01.md
@@ -1,0 +1,3 @@
+# Political Science
+
+Details about Political Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/01.md
@@ -1,3 +1,0 @@
-# Political Science
-
-Details about Political Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Political_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/01.md
@@ -1,0 +1,3 @@
+# Psychology
+
+Details about Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/01.md
@@ -1,3 +1,0 @@
-# Psychology
-
-Details about Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/01.md
@@ -1,0 +1,3 @@
+# Public Health Sciences
+
+Details about Public Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/01.md
@@ -1,3 +1,0 @@
-# Public Health Sciences
-
-Details about Public Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Health_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/01.md
@@ -1,0 +1,3 @@
+# Public Policy
+
+Details about Public Policy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/01.md
@@ -1,3 +1,0 @@
-# Public Policy
-
-Details about Public Policy program.

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/P/Public_Policy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/01.md
@@ -1,3 +1,0 @@
-# Rehabilitation Science
-
-Details about Rehabilitation Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/01.md
@@ -1,0 +1,3 @@
+# Rehabilitation Science
+
+Details about Rehabilitation Science program.

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Rehabilitation_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/01.md
@@ -1,3 +1,0 @@
-# Religion
-
-Details about Religion program.

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/01.md
@@ -1,0 +1,3 @@
+# Religion
+
+Details about Religion program.

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/R/Religion/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/01.md
@@ -1,0 +1,3 @@
+# School and Clinical Child Psychology
+
+Details about School and Clinical Child Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/01.md
@@ -1,3 +1,0 @@
-# School and Clinical Child Psychology
-
-Details about School and Clinical Child Psychology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/School_and_Clinical_Child_Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/01.md
@@ -1,0 +1,3 @@
+# Slavic and East European Languages and Cultures
+
+Details about Slavic and East European Languages and Cultures program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/01.md
@@ -1,3 +1,0 @@
-# Slavic and East European Languages and Cultures
-
-Details about Slavic and East European Languages and Cultures program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Slavic_and_East_European_Languages_and_Cultures/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/01.md
@@ -1,0 +1,3 @@
+# Social Justice Education
+
+Details about Social Justice Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/01.md
@@ -1,3 +1,0 @@
-# Social Justice Education
-
-Details about Social Justice Education program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Justice_Education/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/01.md
@@ -1,3 +1,0 @@
-# Social Work
-
-Details about Social Work program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/01.md
@@ -1,0 +1,3 @@
+# Social Work
+
+Details about Social Work program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Social_Work/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/01.md
@@ -1,3 +1,0 @@
-# Sociology
-
-Details about Sociology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/01.md
@@ -1,0 +1,3 @@
+# Sociology
+
+Details about Sociology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sociology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/01.md
@@ -1,0 +1,3 @@
+# Spanish
+
+Details about Spanish program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/01.md
@@ -1,3 +1,0 @@
-# Spanish
-
-Details about Spanish program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Spanish/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/01.md
@@ -1,0 +1,3 @@
+# Speech-Language Pathology
+
+Details about Speech-Language Pathology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/01.md
@@ -1,3 +1,0 @@
-# Speech-Language Pathology
-
-Details about Speech-Language Pathology program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Speech-Language_Pathology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/01.md
@@ -1,0 +1,3 @@
+# Statistics
+
+Details about Statistics program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/01.md
@@ -1,3 +1,0 @@
-# Statistics
-
-Details about Statistics program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Statistics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/01.md
@@ -1,3 +1,0 @@
-# Sustainability Management
-
-Details about Sustainability Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/01.md
@@ -1,0 +1,3 @@
+# Sustainability Management
+
+Details about Sustainability Management program.

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/S/Sustainability_Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/01.md
@@ -1,3 +1,0 @@
-# Teaching
-
-Details about Teaching program.

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/01.md
@@ -1,0 +1,3 @@
+# Teaching
+
+Details about Teaching program.

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Teaching/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/01.md
@@ -1,3 +1,0 @@
-# Translational Research in the Health Sciences
-
-Details about Translational Research in the Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/01.md
@@ -1,0 +1,3 @@
+# Translational Research in the Health Sciences
+
+Details about Translational Research in the Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/T/Translational_Research_in_the_Health_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/01.md
@@ -1,0 +1,3 @@
+# Urban Design
+
+Details about Urban Design program.

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/01.md
@@ -1,3 +1,0 @@
-# Urban Design
-
-Details about Urban Design program.

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Design/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/01.md
@@ -1,0 +1,3 @@
+# Urban Innovation
+
+Details about Urban Innovation program.

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/01.md
@@ -1,3 +1,0 @@
-# Urban Innovation
-
-Details about Urban Innovation program.

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/U/Urban_Innovation/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/01.md
@@ -1,3 +1,0 @@
-# Visual Studies
-
-Details about Visual Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/01.md
@@ -1,0 +1,3 @@
+# Visual Studies
+
+Details about Visual Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/V/Visual_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/01.md
@@ -1,3 +1,0 @@
-# Women and Gender Studies
-
-Details about Women and Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/01.md
@@ -1,0 +1,3 @@
+# Women and Gender Studies
+
+Details about Women and Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Graduate/W/Women_and_Gender_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/01.md
@@ -1,3 +1,0 @@
-# Accounting
-
-Details about Accounting program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/01.md
@@ -1,0 +1,3 @@
+# Accounting
+
+Details about Accounting program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Accounting/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/01.md
@@ -1,3 +1,0 @@
-# Actuarial Science
-
-Details about Actuarial Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/01.md
@@ -1,0 +1,3 @@
+# Actuarial Science
+
+Details about Actuarial Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Actuarial_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/01.md
@@ -1,0 +1,3 @@
+# African Studies
+
+Details about African Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/01.md
@@ -1,3 +1,0 @@
-# African Studies
-
-Details about African Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/African_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/01.md
@@ -1,0 +1,3 @@
+# Aging and Society
+
+Details about Aging and Society program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/01.md
@@ -1,3 +1,0 @@
-# Aging and Society
-
-Details about Aging and Society program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Aging_and_Society/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/01.md
@@ -1,3 +1,0 @@
-# American Studies
-
-Details about American Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/01.md
@@ -1,0 +1,3 @@
+# American Studies
+
+Details about American Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/American_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/01.md
@@ -1,3 +1,0 @@
-# Anthropology
-
-Details about Anthropology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/01.md
@@ -1,0 +1,3 @@
+# Anthropology
+
+Details about Anthropology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Anthropology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/01.md
@@ -1,3 +1,0 @@
-# Applied Mathematics
-
-Details about Applied Mathematics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/01.md
@@ -1,0 +1,3 @@
+# Applied Mathematics
+
+Details about Applied Mathematics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Applied_Mathematics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/01.md
@@ -1,0 +1,3 @@
+# Archaeology
+
+Details about Archaeology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/01.md
@@ -1,3 +1,0 @@
-# Archaeology
-
-Details about Archaeology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Archaeology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/01.md
@@ -1,3 +1,0 @@
-# Art History
-
-Details about Art History program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/01.md
@@ -1,0 +1,3 @@
+# Art History
+
+Details about Art History program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Art_History/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/01.md
@@ -1,0 +1,3 @@
+# Astrophysics
+
+Details about Astrophysics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/01.md
@@ -1,3 +1,0 @@
-# Astrophysics
-
-Details about Astrophysics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/A/Astrophysics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/01.md
@@ -1,3 +1,0 @@
-# Biochemistry
-
-Details about Biochemistry program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/01.md
@@ -1,0 +1,3 @@
+# Biochemistry
+
+Details about Biochemistry program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biochemistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/01.md
@@ -1,3 +1,0 @@
-# Bioethics
-
-Details about Bioethics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/01.md
@@ -1,0 +1,3 @@
+# Bioethics
+
+Details about Bioethics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Bioethics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/01.md
@@ -1,0 +1,3 @@
+# Biology
+
+Details about Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/01.md
@@ -1,3 +1,0 @@
-# Biology
-
-Details about Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/01.md
@@ -1,0 +1,3 @@
+# Biomedical Engineering
+
+Details about Biomedical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/01.md
@@ -1,3 +1,0 @@
-# Biomedical Engineering
-
-Details about Biomedical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Biomedical_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/01.md
@@ -1,0 +1,3 @@
+# Business Management
+
+Details about Business Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/01.md
@@ -1,3 +1,0 @@
-# Business Management
-
-Details about Business Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/B/Business_Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/01.md
@@ -1,3 +1,0 @@
-# Chemical Engineering
-
-Details about Chemical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/01.md
@@ -1,0 +1,3 @@
+# Chemical Engineering
+
+Details about Chemical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemical_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/01.md
@@ -1,0 +1,3 @@
+# Chemistry
+
+Details about Chemistry program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/01.md
@@ -1,3 +1,0 @@
-# Chemistry
-
-Details about Chemistry program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Chemistry/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/01.md
@@ -1,0 +1,3 @@
+# Civil Engineering
+
+Details about Civil Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/01.md
@@ -1,3 +1,0 @@
-# Civil Engineering
-
-Details about Civil Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Civil_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/01.md
@@ -1,3 +1,0 @@
-# Classics
-
-Details about Classics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/01.md
@@ -1,0 +1,3 @@
+# Classics
+
+Details about Classics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Classics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/01.md
@@ -1,0 +1,3 @@
+# Cognitive Science
+
+Details about Cognitive Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/01.md
@@ -1,3 +1,0 @@
-# Cognitive Science
-
-Details about Cognitive Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Cognitive_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/01.md
@@ -1,3 +1,0 @@
-# Communication Studies
-
-Details about Communication Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/01.md
@@ -1,0 +1,3 @@
+# Communication Studies
+
+Details about Communication Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Communication_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/01.md
@@ -1,0 +1,3 @@
+# Computer Engineering
+
+Details about Computer Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/01.md
@@ -1,3 +1,0 @@
-# Computer Engineering
-
-Details about Computer Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/01.md
@@ -1,0 +1,3 @@
+# Computer Science
+
+Details about Computer Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/01.md
@@ -1,3 +1,0 @@
-# Computer Science
-
-Details about Computer Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Computer_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/01.md
@@ -1,3 +1,0 @@
-# Criminology
-
-Details about Criminology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/01.md
@@ -1,0 +1,3 @@
+# Criminology
+
+Details about Criminology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/C/Criminology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/01.md
@@ -1,3 +1,0 @@
-# Dance
-
-Details about Dance program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/01.md
@@ -1,0 +1,3 @@
+# Dance
+
+Details about Dance program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Dance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/01.md
@@ -1,3 +1,0 @@
-# Data Science
-
-Details about Data Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/01.md
@@ -1,0 +1,3 @@
+# Data Science
+
+Details about Data Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Data_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/01.md
@@ -1,0 +1,3 @@
+# Drama
+
+Details about Drama program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/01.md
@@ -1,3 +1,0 @@
-# Drama
-
-Details about Drama program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/D/Drama/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/01.md
@@ -1,0 +1,3 @@
+# Earth Sciences
+
+Details about Earth Sciences program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/01.md
@@ -1,3 +1,0 @@
-# Earth Sciences
-
-Details about Earth Sciences program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Earth_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/01.md
@@ -1,0 +1,3 @@
+# East Asian Studies
+
+Details about East Asian Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/01.md
@@ -1,3 +1,0 @@
-# East Asian Studies
-
-Details about East Asian Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/East_Asian_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/01.md
@@ -1,3 +1,0 @@
-# Economics
-
-Details about Economics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/01.md
@@ -1,0 +1,3 @@
+# Economics
+
+Details about Economics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Economics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/01.md
@@ -1,0 +1,3 @@
+# Electrical Engineering
+
+Details about Electrical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/01.md
@@ -1,3 +1,0 @@
-# Electrical Engineering
-
-Details about Electrical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/Electrical_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/01.md
@@ -1,0 +1,3 @@
+# English
+
+Details about English program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/01.md
@@ -1,3 +1,0 @@
-# English
-
-Details about English program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/E/English/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/01.md
@@ -1,3 +1,0 @@
-# Film Studies
-
-Details about Film Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/01.md
@@ -1,0 +1,3 @@
+# Film Studies
+
+Details about Film Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Film_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/01.md
@@ -1,0 +1,3 @@
+# Finance
+
+Details about Finance program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/01.md
@@ -1,3 +1,0 @@
-# Finance
-
-Details about Finance program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/Finance/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/01.md
@@ -1,0 +1,3 @@
+# French
+
+Details about French program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/01.md
@@ -1,3 +1,0 @@
-# French
-
-Details about French program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/F/French/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/01.md
@@ -1,0 +1,3 @@
+# Gender Studies
+
+Details about Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/01.md
@@ -1,3 +1,0 @@
-# Gender Studies
-
-Details about Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Gender_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/01.md
@@ -1,3 +1,0 @@
-# Geography
-
-Details about Geography program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/01.md
@@ -1,0 +1,3 @@
+# Geography
+
+Details about Geography program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geography/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/01.md
@@ -1,3 +1,0 @@
-# Geology
-
-Details about Geology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/01.md
@@ -1,0 +1,3 @@
+# Geology
+
+Details about Geology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/G/Geology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/01.md
@@ -1,0 +1,3 @@
+# Health Sciences
+
+Details about Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/01.md
@@ -1,3 +1,0 @@
-# Health Sciences
-
-Details about Health Sciences program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Health_Sciences/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/01.md
@@ -1,3 +1,0 @@
-# History
-
-Details about History program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/01.md
@@ -1,0 +1,3 @@
+# History
+
+Details about History program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/History/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/01.md
@@ -1,0 +1,3 @@
+# Human Biology
+
+Details about Human Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/01.md
@@ -1,3 +1,0 @@
-# Human Biology
-
-Details about Human Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Biology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/01.md
@@ -1,3 +1,0 @@
-# Human Resource Management
-
-Details about Human Resource Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/01.md
@@ -1,0 +1,3 @@
+# Human Resource Management
+
+Details about Human Resource Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/H/Human_Resource_Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/01.md
@@ -1,3 +1,0 @@
-# Indigenous Studies
-
-Details about Indigenous Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/01.md
@@ -1,0 +1,3 @@
+# Indigenous Studies
+
+Details about Indigenous Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Indigenous_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/01.md
@@ -1,3 +1,0 @@
-# Industrial Engineering
-
-Details about Industrial Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/01.md
@@ -1,0 +1,3 @@
+# Industrial Engineering
+
+Details about Industrial Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Industrial_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/01.md
@@ -1,0 +1,3 @@
+# Information Technology
+
+Details about Information Technology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/01.md
@@ -1,3 +1,0 @@
-# Information Technology
-
-Details about Information Technology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Information_Technology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/01.md
@@ -1,0 +1,3 @@
+# International Studies
+
+Details about International Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/01.md
@@ -1,3 +1,0 @@
-# International Studies
-
-Details about International Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/International_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/01.md
@@ -1,3 +1,0 @@
-# Italian
-
-Details about Italian program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/01.md
@@ -1,0 +1,3 @@
+# Italian
+
+Details about Italian program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Italian/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/01.md
@@ -1,3 +1,0 @@
-# Japanese
-
-Details about Japanese program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/01.md
@@ -1,0 +1,3 @@
+# Japanese
+
+Details about Japanese program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Japanese/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/01.md
@@ -1,3 +1,0 @@
-# Journalism
-
-Details about Journalism program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/01.md
@@ -1,0 +1,3 @@
+# Journalism
+
+Details about Journalism program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/I/Journalism/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/01.md
@@ -1,0 +1,3 @@
+# Kinesiology
+
+Details about Kinesiology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/01.md
@@ -1,3 +1,0 @@
-# Kinesiology
-
-Details about Kinesiology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Kinesiology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/01.md
@@ -1,3 +1,0 @@
-# Latin American Studies
-
-Details about Latin American Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/01.md
@@ -1,0 +1,3 @@
+# Latin American Studies
+
+Details about Latin American Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/K/Latin_American_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/01.md
@@ -1,3 +1,0 @@
-# Law
-
-Details about Law program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/01.md
@@ -1,0 +1,3 @@
+# Law
+
+Details about Law program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Law/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/01.md
@@ -1,0 +1,3 @@
+# Linguistics
+
+Details about Linguistics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/01.md
@@ -1,3 +1,0 @@
-# Linguistics
-
-Details about Linguistics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/L/Linguistics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/01.md
@@ -1,3 +1,0 @@
-# Management
-
-Details about Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/01.md
@@ -1,0 +1,3 @@
+# Management
+
+Details about Management program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Management/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/01.md
@@ -1,3 +1,0 @@
-# Materials Engineering
-
-Details about Materials Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/01.md
@@ -1,0 +1,3 @@
+# Materials Engineering
+
+Details about Materials Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Materials_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/01.md
@@ -1,0 +1,3 @@
+# Mathematics
+
+Details about Mathematics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/01.md
@@ -1,3 +1,0 @@
-# Mathematics
-
-Details about Mathematics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mathematics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/01.md
@@ -1,3 +1,0 @@
-# Mechanical Engineering
-
-Details about Mechanical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/01.md
@@ -1,0 +1,3 @@
+# Mechanical Engineering
+
+Details about Mechanical Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Mechanical_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/01.md
@@ -1,3 +1,0 @@
-# Media Studies
-
-Details about Media Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/01.md
@@ -1,0 +1,3 @@
+# Media Studies
+
+Details about Media Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Media_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/01.md
@@ -1,3 +1,0 @@
-# Medieval Studies
-
-Details about Medieval Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/01.md
@@ -1,0 +1,3 @@
+# Medieval Studies
+
+Details about Medieval Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Medieval_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/01.md
@@ -1,3 +1,0 @@
-# Molecular Biology
-
-Details about Molecular Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/01.md
@@ -1,0 +1,3 @@
+# Molecular Biology
+
+Details about Molecular Biology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Molecular_Biology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/01.md
@@ -1,0 +1,3 @@
+# Music
+
+Details about Music program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/01.md
@@ -1,3 +1,0 @@
-# Music
-
-Details about Music program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/M/Music/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/01.md
@@ -1,3 +1,0 @@
-# Neuroscience
-
-Details about Neuroscience program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/01.md
@@ -1,0 +1,3 @@
+# Neuroscience
+
+Details about Neuroscience program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Neuroscience/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/01.md
@@ -1,3 +1,0 @@
-# Nursing
-
-Details about Nursing program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/01.md
@@ -1,0 +1,3 @@
+# Nursing
+
+Details about Nursing program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nursing/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/01.md
@@ -1,0 +1,3 @@
+# Nutrition
+
+Details about Nutrition program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/01.md
@@ -1,3 +1,0 @@
-# Nutrition
-
-Details about Nutrition program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/N/Nutrition/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/01.md
@@ -1,3 +1,0 @@
-# Philosophy
-
-Details about Philosophy program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/01.md
@@ -1,0 +1,3 @@
+# Philosophy
+
+Details about Philosophy program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Philosophy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/01.md
@@ -1,0 +1,3 @@
+# Physics
+
+Details about Physics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/01.md
@@ -1,3 +1,0 @@
-# Physics
-
-Details about Physics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Physics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/01.md
@@ -1,0 +1,3 @@
+# Political Science
+
+Details about Political Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/01.md
@@ -1,3 +1,0 @@
-# Political Science
-
-Details about Political Science program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Political_Science/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/01.md
@@ -1,0 +1,3 @@
+# Psychology
+
+Details about Psychology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/01.md
@@ -1,3 +1,0 @@
-# Psychology
-
-Details about Psychology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Psychology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/01.md
@@ -1,3 +1,0 @@
-# Public Health
-
-Details about Public Health program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/01.md
@@ -1,0 +1,3 @@
+# Public Health
+
+Details about Public Health program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/P/Public_Health/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/01.md
@@ -1,3 +1,0 @@
-# Religious Studies
-
-Details about Religious Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/01.md
@@ -1,0 +1,3 @@
+# Religious Studies
+
+Details about Religious Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Religious_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/01.md
@@ -1,0 +1,3 @@
+# Romance Studies
+
+Details about Romance Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/01.md
@@ -1,3 +1,0 @@
-# Romance Studies
-
-Details about Romance Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Romance_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/01.md
@@ -1,3 +1,0 @@
-# Russian Studies
-
-Details about Russian Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/01.md
@@ -1,0 +1,3 @@
+# Russian Studies
+
+Details about Russian Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/R/Russian_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/01.md
@@ -1,3 +1,0 @@
-# Sociology
-
-Details about Sociology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/01.md
@@ -1,0 +1,3 @@
+# Sociology
+
+Details about Sociology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sociology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/01.md
@@ -1,0 +1,3 @@
+# Software Engineering
+
+Details about Software Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/01.md
@@ -1,3 +1,0 @@
-# Software Engineering
-
-Details about Software Engineering program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Software_Engineering/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/01.md
@@ -1,0 +1,3 @@
+# Spanish
+
+Details about Spanish program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/01.md
@@ -1,3 +1,0 @@
-# Spanish
-
-Details about Spanish program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Spanish/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/01.md
@@ -1,0 +1,3 @@
+# Statistics
+
+Details about Statistics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/01.md
@@ -1,3 +1,0 @@
-# Statistics
-
-Details about Statistics program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Statistics/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/01.md
@@ -1,3 +1,0 @@
-# Sustainable Energy
-
-Details about Sustainable Energy program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/01.md
@@ -1,0 +1,3 @@
+# Sustainable Energy
+
+Details about Sustainable Energy program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/S/Sustainable_Energy/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/01.md
@@ -1,0 +1,3 @@
+# Theatre
+
+Details about Theatre program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/01.md
@@ -1,3 +1,0 @@
-# Theatre
-
-Details about Theatre program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Theatre/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Urban_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Urban_Studies/01.md
@@ -1,0 +1,3 @@
+# Urban Studies
+
+Details about Urban Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/T/Urban_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/T/Urban_Studies/01.md
@@ -1,3 +1,0 @@
-# Urban Studies
-
-Details about Urban Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Design/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/U/Urban_Innovation/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/01.md
@@ -1,0 +1,3 @@
+# Visual Arts
+
+Details about Visual Arts program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/01.md
@@ -1,3 +1,0 @@
-# Visual Arts
-
-Details about Visual Arts program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/V/Visual_Arts/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/01.md
@@ -1,3 +1,0 @@
-# Women and Gender Studies
-
-Details about Women and Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/01.md
@@ -1,0 +1,3 @@
+# Women and Gender Studies
+
+Details about Women and Gender Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/W/Women_and_Gender_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/01.md
@@ -1,3 +1,0 @@
-# World Studies
-
-Details about World Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/01.md
@@ -1,0 +1,3 @@
+# World Studies
+
+Details about World Studies program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Y/World_Studies/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/01.md
@@ -1,3 +1,0 @@
-# Zoology
-
-Details about Zoology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/01.md
@@ -1,0 +1,3 @@
+# Zoology
+
+Details about Zoology program.

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2025/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s01/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s01 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s02/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s02 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s03/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s03 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s04/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s04 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s05/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s05 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s06/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s06 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s07/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s07 - File 5
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/01.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/01.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 1
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/02.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/02.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 2
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/03.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/03.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 3
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/04.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/04.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 4
+
+Placeholder content

--- a/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/05.md
+++ b/universities/University_of_Toronto_Programs/Undergraduate/Z/Zoology/2026/s08/05.md
@@ -1,0 +1,3 @@
+# Accounting_and_Finance - Year1 - s08 - File 5
+
+Placeholder content


### PR DESCRIPTION
This PR adds a proper folder structure template for University of Toronto syllabi to WikiSyllabus. It allows students and contributors to add syllabus information for various programs offered at the university.

Changes Made: 
- Folder structure added for University of Toronto.
- Markdown files created for each program.