### PR TITLE
University of Toronto Computer Science 2025 S1

### DIFF
--- a/universities/university-of-toronto/computer-science/2025/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2025/s01/01.md
@@ -1,0 +1,56 @@
+---
+
+country: "canada"
+
+university: "university-of-toronto"
+
+branch: "computer-science"
+
+version: "2025"
+
+semester: 1
+
+course\_code: "csc108"
+
+course\_title: "introduction-to-computer-programming"
+
+language: "english"
+
+contributor: "@henry4501"
+
+---
+
+
+
+\### Course Objectives
+
+\- Introduce students to fundamental programming concepts.
+
+\- Develop problem-solving and algorithmic thinking skills.
+
+\- Provide practical exposure to Python programming.
+
+
+
+\### Course Content
+
+1\. Basics of Python programming: syntax, variables, control flow.
+
+2\. Functions, recursion, and modular programming.
+
+3\. Data structures: lists, dictionaries, tuples.
+
+4\. File handling and error management.
+
+5\. Introduction to object-oriented programming.
+
+
+
+\### References
+
+1\. University of Toronto CSC108 Course Website: \[https://www.cs.toronto.edu/~csc108/](https://www.cs.toronto.edu/~csc108/)
+
+2\. Mark Guzdial \& Barbara Ericson, \*Introduction to Computing and Programming in Python\*.
+
+
+


### PR DESCRIPTION
Added initial syllabus structure for University of Toronto, Canada.
- Created folder: universities/university-of-toronto/computer-science/2025/s01/
- Added sample syllabus file (01.md) for CSC108 - Introduction to Computer Programming
- Included YAML frontmatter with metadata
- Added course objectives, content, and references
