### PR TITLE
feat: scaffold ETH Zurich Bachelor & Master syllabus placeholders

### DIFF
--- a/universities/eth-zurich/architecture-civil-engineering-masters/2023/s01/01.md
+++ b/universities/eth-zurich/architecture-civil-engineering-masters/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/architecture-civil-engineering/2023/s01/01.md
+++ b/universities/eth-zurich/architecture-civil-engineering/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/engineering-sciences-masters/2023/s01/01.md
+++ b/universities/eth-zurich/engineering-sciences-masters/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/engineering-sciences/2023/s01/01.md
+++ b/universities/eth-zurich/engineering-sciences/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/humanities-political-social-sciences/2023/s01/01.md
+++ b/universities/eth-zurich/humanities-political-social-sciences/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/management-social-sciences/2023/s01/01.md
+++ b/universities/eth-zurich/management-social-sciences/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/natural-sciences-mathematics-masters/2023/s01/01.md
+++ b/universities/eth-zurich/natural-sciences-mathematics-masters/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/natural-sciences-mathematics/2023/s01/01.md
+++ b/universities/eth-zurich/natural-sciences-mathematics/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/system-oriented-natural-sciences-masters/2023/s01/01.md
+++ b/universities/eth-zurich/system-oriented-natural-sciences-masters/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)

--- a/universities/eth-zurich/system-oriented-natural-sciences/2023/s01/01.md
+++ b/universities/eth-zurich/system-oriented-natural-sciences/2023/s01/01.md
@@ -1,0 +1,28 @@
+---
+country: "switzerland"
+university: "eth-zurich"
+branch: "2023"
+version: "2023"
+semester: "1"
+course_code: "CS101"
+course_title: "placeholder-course"
+language: "english"
+contributor: "@djvu2k6"
+---
+
+# Placeholder Course
+
+**⚠️ NOTE:** This is a scaffold placeholder. Contributors can replace this with official ETH Zurich course syllabus.
+
+## Course Objectives
+* To provide a basic framework for the syllabus of this branch.
+* To introduce the placeholder structure for contributors.
+* To maintain consistency with WikiSyllabus formatting.
+
+## Course Content
+- Module 1: Placeholder
+- Module 2: Placeholder
+- Module 3: Placeholder
+
+## References
+- ETH Zurich official course pages (to be updated)


### PR DESCRIPTION
### Summary
This PR adds scaffold placeholders for ETH Zurich Bachelor’s and Master’s degree syllabi in WikiSyllabus. 
It creates the folder structure and placeholder 01.md files for all first-semester courses across all branches.

### Changes
- Created folder structure for ETH Zurich Bachelor branches:
  - architecture-civil-engineering
  - engineering-sciences
  - natural-sciences-mathematics
  - system-oriented-natural-sciences
  - humanities-political-social-sciences

- Created folder structure for ETH Zurich Master branches:
  - architecture-civil-engineering-masters
  - system-oriented-natural-sciences-masters
  - natural-sciences-mathematics-masters
  - management-social-sciences
  - engineering-sciences-masters

- Added placeholder 01.md files in every s01 folder with:
  - Proper YAML frontmatter
  - Contributor GitHub handle
  - Placeholder course objectives, content, and references

### Purpose
- Provides a scaffold for future contributors to add actual ETH Zurich syllabi.
- Ensures consistency with WikiSyllabus folder/file structure.
- Prepares WikiSyllabus for inclusion of one of Europe’s top universities.


### Notes
- Placeholder files are intentionally generic.
- Official ETH Zurich syllabi can be added in later PRs by contributors.
