### PR TITLE
University of Toronto Computer Science 2025 S1

### DIFF
--- a/universities/university-of-toronto/computer-science/2025/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2025/s01/01.md
@@ -1,0 +1,56 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs101"
+course_title: "introduction-to-computer-science"
+language: "english"
+contributor: "@arun-shankar-s"
+---
+
+# CS101: Introduction to Computer Science
+
+## Course Objectives
+* To introduce the fundamental concepts of computer science.
+* To develop problem-solving and programming skills.
+* To understand algorithms, data structures, and software development principles.
+
+## Course Outcomes
+* **CO 1:** Understand basic programming concepts and syntax. *(Cognitive level: Understand)*  
+* **CO 2:** Implement simple algorithms and use data structures effectively. *(Cognitive level: Apply)*  
+* **CO 3:** Analyze the efficiency of algorithms. *(Cognitive level: Analyze)*  
+* **CO 4:** Develop simple software programs using structured programming techniques. *(Cognitive level: Apply)*  
+
+## Course Content
+
+### Module 1: Introduction to Computing
+* Overview of Computer Science
+* History and evolution of computing
+* Hardware and software basics
+
+### Module 2: Programming Fundamentals
+* Variables, data types, and operators
+* Conditional statements and loops
+* Functions and modular programming
+
+### Module 3: Data Structures
+* Arrays, lists, stacks, queues
+* Basic searching and sorting algorithms
+
+### Module 4: Software Development Basics
+* Problem-solving approaches
+* Introduction to algorithms
+* Writing, testing, and debugging programs
+
+### Module 5: Advanced Topics (Optional)
+* Introduction to object-oriented programming
+* Basics of software engineering
+* Overview of computer networks and databases
+
+## References
+1. J. Glenn Brookshear, *Computer Science: An Overview*, 13th Edition, Pearson, 2021.  
+2. Harold Abelson, *Structure and Interpretation of Computer Programs*, MIT Press, 1996.  
+3. Paul Deitel & Harvey Deitel, *C How to Program*, 10th Edition, Pearson, 2017.  
+4. Michael H. Goldwasser & David Letscher, *Data Structures and Algorithms in Java*, 2nd Edition, Wiley, 2018.


### PR DESCRIPTION

File Added: universities/university-of-toronto/computer-science/2025/s01/01.md

- Added sample syllabus file: 01.md for cs101 introduction-to-computer-science.

- Included YAML frontmatter with metadata

- Added course objectives, content, and references

Contributor:

@arun-shankar-s