### PR TITLE
Feature Added: California Institute of Technology | Computer Science | Fall 2025 | S1

### DIFF
--- a/universities/california-institute-of-technology/computer-science/2025/s01/01.md
+++ b/universities/california-institute-of-technology/computer-science/2025/s01/01.md
@@ -1,0 +1,98 @@
+---
+country: "usa"
+university: "california-institute-of-technology"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs1"
+course_title: "introduction-to-computer-programming"
+language: "english"
+contributor: "@joegeorge022"
+---
+
+# CS1: Introduction to Computer Programming (Fall 2025)
+
+## Course Objectives
+
+CS1 is designed to be accessible to students interested in any option, regardless of prior experience. The course is structured around four core values:
+
+1. **CS and programming are for everyone!** - Designed to be accessible to students from any discipline, regardless of prior programming experience.
+
+2. **Projects cover diverse disciplines!** - Weekly projects are themed around different fields (physics, chemistry, engineering, math) to provide relevance across disciplines.
+
+3. **CS1 material is sequenced to set you up for success!** - Three modules: Reading and Modifying Python code, Using Python to Get Things Done, and Another Programming Language and Preparation for Future CS Courses.
+
+4. **CS1 is not an "easy" course, but we want you to succeed!** - Extensive office hours (more than twenty people-hours) and help resources ensure student success.
+
+## Course Content
+
+### Module 0: Reading and Modifying Python Code
+* Working with existing codebases (most code written won't be from scratch)
+* Navigation and understanding of existing Python code
+* Modifying existing code for research applications
+
+### Module 1: Using Python to Get Things Done
+* Creating mental models of what Python is doing
+* Effective debugging and writing small programs from scratch
+* Core Python programming concepts and structures
+
+### Module 2: Another Programming Language and Preparation for Future CS Courses
+* Introduction to Java programming language
+* Comparison with Python
+* Preparation for future CS courses and research applications
+* Understanding features needed for C++, C, Rust, and Julia
+
+## Course Schedule (Fall 2025)
+
+### Key Topics Covered:
+* **Variables, Types, and Functions** - Basic Python syntax and function definition
+* **Lists, Iteration, and Selection** - Lists, for loops, if statements
+* **Functions and Return Values** - Writing functions and handling return values
+* **While Loops** - Indefinite loops and common loop patterns
+* **Dictionaries** - Storing mappings and key-value pairs
+* **Exceptions** - Error handling in Python
+* **Objects and Classes** - Object-oriented programming concepts
+* **Recursion** - Recursive programming techniques
+
+### Major Projects:
+* **project01 (Battleship, part 1)** - Fundamental Python concepts with emphasis on conditionals and lists
+* **project02** - Advanced Python programming
+* **project03** - Working with hardware (Trinkey device)
+
+### Assessments:
+* **In-Class Quiz** - Week 10 (Wednesday, October 22)
+* **In-Class Midterm** - Week 22 (Wednesday, November 19)
+* **In-Class Final** - Week 26 (Friday, November 28)
+
+## Assessment Methods
+
+### Formative Assessments (Diagnostics)
+* In-class exercises during lectures
+* Multiple choice, fill-in-the-blank, and explanation questions
+* Collaborative work during lecture time
+* Second attempt opportunities outside class
+* Drop two lowest diagnostic scores
+
+### Summative Assessments
+* **Written Quiz** - 40% minimum to pass
+* **Written Midterm** - 60% minimum to pass
+* **Written Final** - 60% minimum to pass
+* Must pass at least 2 of the 3 assessments
+
+### Projects
+* Weekly themed projects across different disciplines
+* Must complete every DUE and earn at least 50% on each project
+* Project average counts toward final grade
+
+### Grading Formula
+Shadow Grade = 0.5 × (best two of quiz, midterm, final) + 0.4 × (Project Average) + 0.1 × (Diagnostic Average)
+
+## References
+
+* Course Website: [https://cs1.caltech.codes/25fa/](https://cs1.caltech.codes/25fa/)
+* Official Syllabus: [https://cs1.caltech.codes/25fa/documents/syllabus.pdf](https://cs1.caltech.codes/25fa/documents/syllabus.pdf)
+* Instructor: Prof. Blank (blank@caltech.edu, they/them)
+* Office: Annenberg 115, (626) 395-1765
+* Course Email: cs001@caltech.edu
+* Teaching Assistants: 14 TAs including Justin Yokota, Jinhuang Zhou, Hopper, Bisrat Kassahun, and others
+* Course Staff: Extensive support with more than twenty people-hours of office hours

--- a/universities/california-institute-of-technology/computer-science/2025/s01/02.md
+++ b/universities/california-institute-of-technology/computer-science/2025/s01/02.md
@@ -1,0 +1,112 @@
+---
+country: "usa"
+university: "california-institute-of-technology"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs2"
+course_title: "introduction-to-programming-methods"
+language: "english"
+contributor: "@joegeorge022"
+---
+
+# CS 2: Introduction to Programming Methods (Winter 2025)
+
+## Course Objectives
+
+This course is intended as a continuation of CS 1. We focus on abstraction in programming—both in design of programs and data storage. We discuss and implement fundamental data structures and algorithms via a series of labs and projects. We will grade on correctness and efficiency of our programs.
+
+* Master Java programming language and object-oriented programming concepts (Cognitive Knowledge Level: Apply)
+* Design and implement fundamental data structures from scratch (Cognitive Knowledge Level: Apply)
+* Analyze algorithmic efficiency using asymptotic analysis (Cognitive Knowledge Level: Analyze)
+* Apply recursive backtracking and other algorithmic techniques (Cognitive Knowledge Level: Apply)
+* Debug and test programs using professional development tools (Cognitive Knowledge Level: Apply)
+
+## Course Content
+
+### Module 1: Object-Oriented Programming and Java Fundamentals
+* Introduction to Java and OOP
+  - Designing Java classes
+  - Designing data structures
+  - Object-oriented programming principles
+* Problem decomposition and API usage
+  - Using an API effectively
+  - Helper methods and code organization
+  - Reading documentation and Java String API
+
+### Module 2: Data Structures and Collections
+* Basic data structure trade-offs
+  - Lists, Sets, and Maps
+  - Nested data structures and efficiency considerations
+  - Client usage of stacks and queues
+* Implementation of core data structures
+  - ArrayIntList and ArrayList implementation
+  - LinkedList implementation
+  - Stacks and queues implementation
+
+### Module 3: Advanced Data Structures
+* Trees and Binary Search Trees
+  - Tree data structure fundamentals
+  - Binary search trees and tree algorithms
+  - N-ary trees and decision trees
+* Hash Tables and Hashing
+  - Hash table data structure
+  - Hash functions and collision resolution
+  - Efficiency analysis
+
+### Module 4: Algorithms and Analysis
+* Recursion and Recursive Backtracking
+  - The power of recursion
+  - Recursive backtracking pattern
+  - Algorithmic problem solving
+* Asymptotic Analysis
+  - Big-Theta notation and complexity analysis
+  - Recurrence relations
+  - Efficiency trade-offs
+
+### Module 5: Advanced Topics
+* Sorting Algorithms
+  - Comparison-based sorting
+  - Efficiency analysis of sorting algorithms
+* Graphs and Graph Algorithms
+  - Graph representation and DAGs
+  - Single-source shortest paths
+  - Graph traversal algorithms
+* Heaps and Priority Queues
+  - Heap data structure
+  - Priority queue implementation
+
+## Assessment Methods
+
+### Labs (20% of grade)
+* Pair programming exercises
+* Testing, debugging, and implementation practice
+* Bridge between lecture and projects
+* Must attend assigned lab section to receive credit
+* Drop lowest lab grade
+
+### Projects (40% of grade)
+* **project01 (ciphers)** - Transition to Java programming
+* **project02 (hangman)** - Using built-in Java collections as a client
+* **project03 (html fixer)** - Algorithmic efficiency and stacks/queues
+* **project04 (synthesizer)** - Building data structures from scratch
+* **project05 (markov)** - Implementing hash table and BST
+* **project06 (beavermaps)** - Building and using graph data structures
+
+### Quizzes (40% of grade)
+* **quiz01** - Code analysis and data structure selection
+* **quiz02** - Non-programming skills assessment
+* In-person written assessments
+
+## Prerequisites
+* CS 1: Introduction to Computer Programming
+
+## References
+
+* Course Website: [https://debuggi.ng/25wi/](https://debuggi.ng/25wi/)
+* Official Syllabus: [https://debuggi.ng/25wi/documents/syllabus.pdf](https://debuggi.ng/25wi/documents/syllabus.pdf)
+* Instructor: Prof. Adam Blank (blank@caltech.edu, they/them) - Annenberg 115
+* Course Email: cs002@caltech.edu
+* Teaching Assistants: Hopper, Vansh Tibrewal, Aiden Di Carlo, Ellie Chen, Jinhuang Zhou, Maya Keys, Max Chen, Pratyush Singh, Ritali Jain, Robert Walker, Ryan Lin, Sani Deshmukh
+* Lecture: Beckman Institute Auditorium, MWF 02:00 - 02:55 PM
+* Extension Requests: https://extensions.caltech.codes/

--- a/universities/california-institute-of-technology/computer-science/2025/s01/03.md
+++ b/universities/california-institute-of-technology/computer-science/2025/s01/03.md
@@ -1,0 +1,98 @@
+---
+country: "usa"
+university: "california-institute-of-technology"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs21"
+course_title: "decidability-and-tractability"
+language: "english"
+contributor: "@joegeorge022"
+---
+
+# CS 21: Decidability and Tractability (Winter 2025)
+
+## Course Objectives
+
+CS 21 provides a rigorous introduction to the theoretical foundations of computer science, focusing on decidability and tractability of computational problems.
+
+* Understand fundamental concepts in computational complexity theory (Cognitive Knowledge Level: Remember)
+* Analyze the decidability of computational problems (Cognitive Knowledge Level: Analyze)
+* Apply reduction techniques to prove problem complexity (Cognitive Knowledge Level: Apply)
+* Evaluate the tractability of algorithmic solutions (Cognitive Knowledge Level: Evaluate)
+* Connect theoretical concepts to practical computational limitations (Cognitive Knowledge Level: Analyze)
+
+## Course Content
+
+### Module 1: Foundations of Computability
+* Turing machines and computability
+  - Formal definition of computation
+  - Church-Turing thesis
+  - Universal Turing machines
+* Decidability and undecidability
+  - Decidable and undecidable languages
+  - The halting problem
+  - Rice's theorem
+
+### Module 2: Complexity Classes
+* Time and space complexity
+  - Big-O notation and complexity analysis
+  - Polynomial time and exponential time
+  - Space complexity and PSPACE
+* P, NP, and beyond
+  - The class P of polynomial-time problems
+  - The class NP and NP-completeness
+  - NP-hard problems
+
+### Module 3: Reductions and NP-Completeness
+* Polynomial-time reductions
+  - Karp reductions and Cook reductions
+  - Completeness and hardness
+  - Standard NP-complete problems
+* Classical NP-complete problems
+  - SAT (Satisfiability)
+  - 3-SAT and other variants
+  - Vertex Cover, Clique, and other graph problems
+
+### Module 4: Advanced Complexity Theory
+* Beyond NP
+  - The polynomial hierarchy
+  - PSPACE and PSPACE-complete problems
+  - Exponential time classes
+* Approximation algorithms
+  - Approximation ratios and hardness of approximation
+  - PTAS and FPTAS
+  - Inapproximability results
+
+### Module 5: Specialized Topics
+* Randomized computation
+  - BPP and other randomized classes
+  - Probabilistic algorithms
+  - Derandomization
+* Circuit complexity and lower bounds
+  - Boolean circuits
+  - Circuit lower bounds
+  - Connections to algorithms
+
+## Assessment Methods
+
+### Problem Sets
+* Weekly theoretical problem assignments
+* Proof-based exercises
+* Complexity analysis problems
+
+### Examinations
+* Midterm examination on computability theory
+* Final examination on complexity theory
+* Regular quizzes on theoretical concepts
+
+## Prerequisites
+* CS 2: Introduction to Programming Methods
+* Strong mathematical background
+
+## References
+
+* Course Website: [https://users.cms.caltech.edu/~umans/cs21/](https://users.cms.caltech.edu/~umans/cs21/)
+* Official Syllabus: [https://users.cms.caltech.edu/~umans/cs21/syllabus25.pdf](https://users.cms.caltech.edu/~umans/cs21/syllabus25.pdf)
+* Caltech Computer Science Department
+* Computational complexity theory textbooks and research papers

--- a/universities/california-institute-of-technology/computer-science/2025/s01/04.md
+++ b/universities/california-institute-of-technology/computer-science/2025/s01/04.md
@@ -1,0 +1,100 @@
+---
+country: "usa"
+university: "california-institute-of-technology"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs24"
+course_title: "introduction-to-computing-systems"
+language: "english"
+contributor: "@joegeorge022"
+---
+
+# CS 24: Introduction to Computing Systems (Fall 2025)
+
+## Course Objectives
+
+CS 24 provides a basic introduction to computer systems, including hardware-software interface, computer architecture, and operating systems. The course emphasizes computer system abstractions and the hardware and software techniques necessary to support them.
+
+By the end of the course, you will be able to:
+
+* Differentiate between how Java and C code run on modern machines (Cognitive Knowledge Level: Analyze)
+* Translate between high-level and low-level programming languages (Cognitive Knowledge Level: Apply)
+* Defend trade-offs between efficiency, security, readability, and performance in your programs (Cognitive Knowledge Level: Evaluate)
+* Explain the mechanisms modern systems use to protect, manage, and virtualize memory (Cognitive Knowledge Level: Analyze)
+* Describe how modern computers give the illusion of running multiple things at once (Cognitive Knowledge Level: Understand)
+* Design a concurrent program which does not have any race conditions (Cognitive Knowledge Level: Create)
+
+## Course Content
+
+### Module 1: Computing Systems Perspectives and Memory
+* Perspectives on computing systems
+  - What is this course about?
+  - How do computers represent information?
+  - Hexadecimal and number bases
+* Memory abstractions
+  - What does an abstraction for memory look like?
+  - Memory representation and organization
+  - Fixed-width integers and negative number representation
+
+### Module 2: ARM64 Assembly Language
+* ARM64 introduction
+  - What is ARM64 and why should I care about assembly?
+  - Understanding basic assembly programs and instructions
+  - mov and other basic instructions
+* ARM64 conditionals and control flow
+  - How does branching work in ARM64?
+  - What is a label?
+  - Translating if statements into assembly
+
+### Module 3: ARM64 Procedures and Stack Management
+* ARM64 procedures
+  - How do function calls and returns work?
+  - What is 'the stack' really?
+  - More ARM64 procedures and recursion
+* Recursive procedures
+  - How does recursion work using the stack?
+  - ARM64 recursive procedures
+
+### Module 4: Security and Buffer Overflows
+* Security concepts
+  - What happens if we read past the end of a buffer?
+  - How can we exploit buffer overflows?
+  - Security mechanisms in modern systems
+
+### Module 5: System Abstractions and Virtualization
+* Virtualization techniques
+  - Memory virtualization
+  - Processing virtualization
+  - Communication virtualization
+* Dynamic resource management
+  - Common-case optimization
+  - Isolation and naming
+  - System protection mechanisms
+
+## Assessment Methods
+
+### Programming Projects
+* **pretest (disk)** - Orientation to CS 24, representation, number bases, and pointer review
+* **project01 (jvm)** - Building a simplified Java Virtual Machine (JVM) to process bytecode and execute Java programs on a custom virtual machine
+
+### Examinations
+* **Quiz** - Written in-person assessment during lecture time
+* **Midterm** - Written in-person assessment during lecture time
+* **Final Exam** - Cumulative written exam during final exam period
+* Approximately 50% of questions pulled directly from in-class exercises
+
+## Prerequisites
+* CS 2: Introduction to Programming Methods
+* CS 3: Additional programming course
+
+## References
+
+* Course Website: [https://com.puter.systems/25fa/](https://com.puter.systems/25fa/)
+* Official Syllabus: [https://com.puter.systems/25fa/documents/syllabus.pdf](https://com.puter.systems/25fa/documents/syllabus.pdf)
+* Instructor: Prof. Ordentlich (eordentl@caltech.edu, he/him) - Annenberg 122
+* Instructor: Prof. Blank (blank@caltech.edu, they/them) - Annenberg 115
+* Course Email: cs024@caltech.edu
+* Teaching Assistants: Hopper, Vansh Tibrewal, Reiden Walker, Brady Bhalla, Ellie Chen, Simone Shevchuk, Zachary Huang
+* Lecture: Beckman Institute Auditorium, MWF 11:00 - 11:55 AM
+* Extension Request Form: https://extensions.caltech.codes/

--- a/universities/california-institute-of-technology/computer-science/2025/s01/05.md
+++ b/universities/california-institute-of-technology/computer-science/2025/s01/05.md
@@ -1,0 +1,99 @@
+---
+country: "usa"
+university: "california-institute-of-technology"
+branch: "computer-science"
+version: "2025"
+semester: 1
+course_code: "cs38"
+course_title: "introduction-to-algorithms"
+language: "english"
+contributor: "@joegeorge022"
+---
+
+# CS 38: Introduction to Algorithms
+
+## Course Objectives
+
+CS 38 provides a rigorous introduction to algorithm design, analysis, and implementation. Students will learn fundamental algorithmic techniques and develop skills in analyzing algorithm efficiency and correctness.
+
+* Master fundamental algorithmic design techniques (Cognitive Knowledge Level: Apply)
+* Analyze algorithm time and space complexity using asymptotic notation (Cognitive Knowledge Level: Analyze)
+* Implement and test various algorithmic solutions to computational problems (Cognitive Knowledge Level: Apply)
+* Prove algorithm correctness and optimality when possible (Cognitive Knowledge Level: Analyze)
+* Apply algorithmic thinking to solve complex computational challenges (Cognitive Knowledge Level: Create)
+
+## Course Content
+
+### Module 1: Algorithm Analysis and Design
+* Asymptotic notation and complexity analysis
+  - Big O, Omega, and Theta notation
+  - Best, average, and worst-case analysis
+  - Recurrence relations and solving techniques
+* Divide and conquer algorithms
+  - Merge sort and quicksort
+  - Binary search and applications
+  - Master theorem and its applications
+
+### Module 2: Sorting and Searching Algorithms
+* Comparison-based sorting algorithms
+  - Heap sort and priority queues
+  - Radix sort and counting sort
+  - Lower bounds for comparison-based sorting
+* Searching algorithms and data structures
+  - Hash tables and collision resolution
+  - Binary search trees and balanced trees
+  - String matching algorithms
+
+### Module 3: Dynamic Programming
+* Principles of dynamic programming
+  - Optimal substructure and overlapping subproblems
+  - Memoization and tabulation techniques
+* Classic dynamic programming problems
+  - Longest common subsequence
+  - Knapsack problems
+  - Edit distance and sequence alignment
+
+### Module 4: Graph Algorithms
+* Graph representation and basic algorithms
+  - Depth-first search (DFS) and breadth-first search (BFS)
+  - Topological sorting and cycle detection
+* Shortest path algorithms
+  - Dijkstra's algorithm
+  - Bellman-Ford algorithm
+  - Floyd-Warshall algorithm
+* Minimum spanning trees
+  - Kruskal's and Prim's algorithms
+  - Union-Find data structure
+
+### Module 5: Advanced Algorithmic Techniques
+* Greedy algorithms
+  - Activity selection problem
+  - Huffman coding
+  - Greedy algorithm design principles
+* Network flow algorithms
+  - Maximum flow problem
+  - Bipartite matching
+  - Minimum cost flow
+
+## Assessment Methods
+
+### Programming Assignments
+* Algorithm implementation projects
+* Complexity analysis exercises
+* Algorithm design challenges
+
+### Examinations
+* Midterm examination on algorithm analysis
+* Final examination on algorithmic design techniques
+* Regular problem-solving quizzes
+
+## Prerequisites
+* CS 2: Introduction to Programming Methods
+* Strong foundation in data structures and algorithms
+
+## References
+
+* Course Website: [https://users.cms.caltech.edu/~umans/cs38/](https://users.cms.caltech.edu/~umans/cs38/)
+* Official Syllabus: [https://users.cms.caltech.edu/~umans/cs38/syllabus.pdf](https://users.cms.caltech.edu/~umans/cs38/syllabus.pdf)
+* Caltech Computer Science Department
+* Algorithm textbooks and complexity analysis resources


### PR DESCRIPTION
### What I Added
Added the official CS1: Introduction to Computer Programming syllabus for California Institute of Technology (Fall 2025).

### Course Details
- **File**: `universities/california-institute-of-technology/computer-science/2025/s01/01.md`
- **Sources**: [Official Caltech CS1 Course Website](https://cs1.caltech.codes/25fa/) and [Syllabus PDF](https://cs1.caltech.codes/25fa/documents/syllabus.pdf)
- **Content**: All data sourced from official Caltech materials (no template content)

### Key Features
- Three-module structure: Reading/Modifying Python → Using Python → Java/Preparation
- Real projects: Battleship, hardware integration with Trinkey device
- Actual assessment dates: Quiz (Oct 22), Midterm (Nov 19), Final (Nov 28)
- Complete staff info: Prof. Blank, 14 TAs, extensive office hours

### Structure
- Follows WikiSyllabus conventions (lowercase with hyphens)
- Proper YAML frontmatter with contributor attribution: @joegeorge022
- Expands WikiSyllabus to include one of the world's top science universities

Addresses the issue #125 