### PR TITLE
University of Toronto Computer Science 2022 S1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "WikiSyllabus",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/universities/university-of-toronto/computer-science/2022/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/01.md
@@ -1,41 +1,91 @@
 ---
----
-
 country: "canada"
 university: "university-of-toronto"
 branch: "computer-science"
-version: "2022"
+scheme: "2022"
 semester: 1
 course_code: "CSC108H1"
 course_title: "introduction-to-computer-programming"
 language: "english"
 contributor: "@joshna12"
-
 ---
 
-## Course Description
+## Course Objectives
 
-This course provides an Introduction to Computer Programming. By the end of this course, students should be comfortable programming in Python, understand why good style is critical, and be familiar with core computer science topics like algorithms and complexity.
+1. Understand basic Python programming concepts (Cognitive knowledge level: Understand)
+2. Apply problem-solving and algorithmic thinking to programming tasks (Cognitive knowledge level: Apply)
+3. Demonstrate debugging, testing, and code style best practices (Cognitive knowledge level: Apply)
+4. Analyze algorithms and understand basic complexity (Cognitive knowledge level: Analyze)
 
-## Communication
+## Course Content
 
-Contact the course instructors for personal issues (illness, emergencies) at: `csc108-2022-01@cs.toronto.edu`.
-For general course-related questions (concept clarification, assignments), use Piazza or visit office hours. Do not use Quercus messaging for CSC108 queries.
+### Module 1: Introduction to Python
 
-## Textbook
+- Variables and Data Types
+- Expressions and Statements
+- Input and Output
+- Functions
 
-**Recommended:** _Practical Programming (3rd ed): An Introduction to Computer Science Using Python 3_ (available as an eBook).
+### Module 2: Control Flow
 
-## Instructors (example roles listed in the syllabus)
+- Conditional Statements (`if`, `elif`, `else`)
+- Loops (`for`, `while`)
+- Iterables and Ranges
 
-- Tom Fairgrieve — Course Coordinator
-- Paul Gries — Instructor
-- Angela Zavaleta Bernuy — Instructor
-- Saima Ali — Instructor
+### Module 3: Data Structures
 
-_(Replace or update instructor names/dates if needed for your specific term.)_
+- Lists, Tuples, Dictionaries, Sets
+- Indexing and Slicing
+- Iterating over Data Structures
 
-## Marking Scheme (summary)
+### Module 4: Functions and Scope
+
+- Defining and Calling Functions
+- Parameters and Return Values
+- Variable Scope
+- Recursion (basic examples)
+
+### Module 5: Object-Oriented Programming
+
+- Classes and Objects
+- Methods and Attributes
+- Inheritance and Encapsulation
+
+### Module 6: Modules and Packages
+
+- Using Standard Library Modules
+- Creating Modules and Packages
+- Import Statements
+
+### Module 7: File I/O
+
+- Reading and Writing Files
+- Working with CSV and Text Files
+
+### Module 8: Debugging and Testing
+
+- Debugging Techniques
+- Writing Unit Tests
+- Using Python’s `unittest` Module
+
+### Module 9: Algorithms and Complexity
+
+- Basic Searching and Sorting
+- Big O Notation Overview
+- Algorithm Analysis
+
+## References
+
+- Gries, P., Campbell, T., Montojo, J. – Practical Programming: An Introduction to Computer Science Using Python 3 (3rd ed), Pearson, 2013
+- Downey, A. – Think Python: How to Think Like a Computer Scientist (2nd ed), O’Reilly Media, 2015
+
+## Assignments
+
+- Assignment 1: Thu Feb 3 — before 5:00 pm
+- Assignment 2: Thu Mar 10 — before 5:00 pm
+- Assignment 3: Thu Mar 31 — before 5:00 pm
+
+## Marking Scheme
 
 - Prepare Exercises: 5% (11 exercises; best 10 count; 0.5% each)
 - Perform Exercises: 20% (11 exercises; best 10 count; 2% each)
@@ -52,20 +102,12 @@ _(Replace or update instructor names/dates if needed for your specific term.)_
 
 ## Term Tests and Final Assessment
 
-- Midterm Test: scheduled during the term (see course calendar).
-- Final Assessment: scheduled in the final assessment period.
-
-## Assignments and Late Penalty
-
-Assignments are submitted electronically (MarkUs). Typical due-date policy example:
-
-- 12 minute grace period after the deadline with no penalty.
-- After that, a late penalty applies (e.g., 1% per 6 minutes for a limited period).  
-  **Always check the specific course page for exact policy.**
+- Midterm Test: scheduled during the term (see course calendar)
+- Final Assessment: scheduled in the final assessment period
 
 ## Academic Integrity
 
-All submitted work must be your own. Avoid using or sharing solutions from unauthorized sources. The department uses tools to detect similar code. Read UofT's Code of Behaviour on Academic Matters.
+All submitted work must be your own. Avoid using or sharing solutions from unauthorized sources. The department uses tools to detect similar code.
 
 ## Accessibility Needs
 
@@ -73,11 +115,4 @@ Students requiring accommodations should contact Student Life | Accessibility Se
 
 ## Special Consideration
 
-If illness or an emergency prevents you from completing work, apply to the Course Coordinator via the special consideration process (details posted on the course page).
-
-## Example Schedule / Important Dates
-
-- Assignment 1: Thu Feb 3 — before 5:00 pm
-- Midterm Test: Wed Feb 16
-- Assignment 2: Thu Mar 10 — before 5:00 pm
-- Assignment 3: Thu Mar 31 — before 5:00 pm
+If illness or an emergency prevents you from completing work, apply to the Course Coordinator via the special consideration process.

--- a/universities/university-of-toronto/computer-science/2022/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/01.md
@@ -1,0 +1,83 @@
+---
+---
+
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+version: "2022"
+semester: 1
+course_code: "CSC108H1"
+course_title: "introduction-to-computer-programming"
+language: "english"
+contributor: "@joshna12"
+
+---
+
+## Course Description
+
+This course provides an Introduction to Computer Programming. By the end of this course, students should be comfortable programming in Python, understand why good style is critical, and be familiar with core computer science topics like algorithms and complexity.
+
+## Communication
+
+Contact the course instructors for personal issues (illness, emergencies) at: `csc108-2022-01@cs.toronto.edu`.
+For general course-related questions (concept clarification, assignments), use Piazza or visit office hours. Do not use Quercus messaging for CSC108 queries.
+
+## Textbook
+
+**Recommended:** _Practical Programming (3rd ed): An Introduction to Computer Science Using Python 3_ (available as an eBook).
+
+## Instructors (example roles listed in the syllabus)
+
+- Tom Fairgrieve — Course Coordinator
+- Paul Gries — Instructor
+- Angela Zavaleta Bernuy — Instructor
+- Saima Ali — Instructor
+
+_(Replace or update instructor names/dates if needed for your specific term.)_
+
+## Marking Scheme (summary)
+
+- Prepare Exercises: 5% (11 exercises; best 10 count; 0.5% each)
+- Perform Exercises: 20% (11 exercises; best 10 count; 2% each)
+- Assignments: 28% (A1 8%, A2 10%, A3 10%)
+- Research Activities: 2% (complete all 4 to earn 2%)
+- Midterm Test: 15%
+- Final Assessment: 30%
+
+## PCRS: Prepare, Rehearse, Perform
+
+- **Prepare:** Watch lecture videos and complete short preparation exercises.
+- **Rehearse:** Practice during lecture time with instructor/TA support.
+- **Perform:** Complete graded Perform exercises using MarkUs.
+
+## Term Tests and Final Assessment
+
+- Midterm Test: scheduled during the term (see course calendar).
+- Final Assessment: scheduled in the final assessment period.
+
+## Assignments and Late Penalty
+
+Assignments are submitted electronically (MarkUs). Typical due-date policy example:
+
+- 12 minute grace period after the deadline with no penalty.
+- After that, a late penalty applies (e.g., 1% per 6 minutes for a limited period).  
+  **Always check the specific course page for exact policy.**
+
+## Academic Integrity
+
+All submitted work must be your own. Avoid using or sharing solutions from unauthorized sources. The department uses tools to detect similar code. Read UofT's Code of Behaviour on Academic Matters.
+
+## Accessibility Needs
+
+Students requiring accommodations should contact Student Life | Accessibility Services as soon as possible.
+
+## Special Consideration
+
+If illness or an emergency prevents you from completing work, apply to the Course Coordinator via the special consideration process (details posted on the course page).
+
+## Example Schedule / Important Dates
+
+- Assignment 1: Thu Feb 3 — before 5:00 pm
+- Midterm Test: Wed Feb 16
+- Assignment 2: Thu Mar 10 — before 5:00 pm
+- Assignment 3: Thu Mar 31 — before 5:00 pm

--- a/universities/university-of-toronto/computer-science/2022/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/01.md
@@ -2,9 +2,9 @@
 country: "canada"
 university: "university-of-toronto"
 branch: "computer-science"
-scheme: "2022"
+version: "2022"
 semester: 1
-course_code: "CSC108H1"
+course_code: "csc108h1"
 course_title: "introduction-to-computer-programming"
 language: "english"
 contributor: "@joshna12"
@@ -16,6 +16,8 @@ contributor: "@joshna12"
 2. Apply problem-solving and algorithmic thinking to programming tasks (Cognitive knowledge level: Apply)
 3. Demonstrate debugging, testing, and code style best practices (Cognitive knowledge level: Apply)
 4. Analyze algorithms and understand basic complexity (Cognitive knowledge level: Analyze)
+
+---
 
 ## Course Content
 
@@ -74,25 +76,33 @@ contributor: "@joshna12"
 - Big O Notation Overview
 - Algorithm Analysis
 
+---
+
 ## References
 
-- Gries, P., Campbell, T., Montojo, J. – Practical Programming: An Introduction to Computer Science Using Python 3 (3rd ed), Pearson, 2013
-- Downey, A. – Think Python: How to Think Like a Computer Scientist (2nd ed), O’Reilly Media, 2015
+- Gries, P., Campbell, T., Montojo, J. – _Practical Programming: An Introduction to Computer Science Using Python 3_ (3rd ed), Pearson, 2013
+- Downey, A. – _Think Python: How to Think Like a Computer Scientist_ (2nd ed), O’Reilly Media, 2015
+
+---
 
 ## Assignments
 
-- Assignment 1: Thu Feb 3 — before 5:00 pm
-- Assignment 2: Thu Mar 10 — before 5:00 pm
-- Assignment 3: Thu Mar 31 — before 5:00 pm
+- **Assignment 1:** Thu Feb 3 — before 5:00 pm
+- **Assignment 2:** Thu Mar 10 — before 5:00 pm
+- **Assignment 3:** Thu Mar 31 — before 5:00 pm
+
+---
 
 ## Marking Scheme
 
-- Prepare Exercises: 5% (11 exercises; best 10 count; 0.5% each)
-- Perform Exercises: 20% (11 exercises; best 10 count; 2% each)
-- Assignments: 28% (A1 8%, A2 10%, A3 10%)
-- Research Activities: 2% (complete all 4 to earn 2%)
-- Midterm Test: 15%
-- Final Assessment: 30%
+- Prepare Exercises: **5%** (11 exercises; best 10 count; 0.5% each)
+- Perform Exercises: **20%** (11 exercises; best 10 count; 2% each)
+- Assignments: **28%** (A1 8%, A2 10%, A3 10%)
+- Research Activities: **2%** (complete all 4 to earn 2%)
+- Midterm Test: **15%**
+- Final Assessment: **30%**
+
+---
 
 ## PCRS: Prepare, Rehearse, Perform
 
@@ -100,19 +110,27 @@ contributor: "@joshna12"
 - **Rehearse:** Practice during lecture time with instructor/TA support.
 - **Perform:** Complete graded Perform exercises using MarkUs.
 
+---
+
 ## Term Tests and Final Assessment
 
-- Midterm Test: scheduled during the term (see course calendar)
-- Final Assessment: scheduled in the final assessment period
+- **Midterm Test:** Scheduled during the term (see course calendar).
+- **Final Assessment:** Scheduled in the final assessment period.
+
+---
 
 ## Academic Integrity
 
 All submitted work must be your own. Avoid using or sharing solutions from unauthorized sources. The department uses tools to detect similar code.
 
+---
+
 ## Accessibility Needs
 
-Students requiring accommodations should contact Student Life | Accessibility Services as soon as possible.
+Students requiring accommodations should contact **Student Life | Accessibility Services** as soon as possible.
+
+---
 
 ## Special Consideration
 
-If illness or an emergency prevents you from completing work, apply to the Course Coordinator via the special consideration process.
+If illness or an emergency prevents you from completing work, apply to the **Course Coordinator** via the special consideration process.

--- a/universities/university-of-toronto/computer-science/2022/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/01.md
@@ -2,9 +2,9 @@
 country: "canada"
 university: "university-of-toronto"
 branch: "computer-science"
-version: "2022"
+scheme: "2022"
 semester: 1
-course_code: "csc108h1"
+course_code: "CSC108H1"
 course_title: "introduction-to-computer-programming"
 language: "english"
 contributor: "@joshna12"
@@ -12,125 +12,82 @@ contributor: "@joshna12"
 
 ## Course Objectives
 
-1. Understand basic Python programming concepts (Cognitive knowledge level: Understand)
-2. Apply problem-solving and algorithmic thinking to programming tasks (Cognitive knowledge level: Apply)
-3. Demonstrate debugging, testing, and code style best practices (Cognitive knowledge level: Apply)
-4. Analyze algorithms and understand basic complexity (Cognitive knowledge level: Analyze)
-
----
+1. Learn fundamental programming concepts using Python
+2. Develop problem-solving and algorithmic thinking skills
+3. Write structured, readable, and efficient Python programs
+4. Understand how to test and debug programs effectively
 
 ## Course Content
 
-### Module 1: Introduction to Python
+### Module 1: Introduction to Programming
 
-- Variables and Data Types
-- Expressions and Statements
-- Input and Output
-- Functions
+- Basics of computer systems and programming
+- Python syntax, variables, and data types
+- Expressions, operators, and type conversion
 
 ### Module 2: Control Flow
 
-- Conditional Statements (`if`, `elif`, `else`)
+- Conditional statements (`if`, `elif`, `else`)
 - Loops (`for`, `while`)
-- Iterables and Ranges
+- Nested control structures
 
-### Module 3: Data Structures
+### Module 3: Functions and Modularity
 
-- Lists, Tuples, Dictionaries, Sets
-- Indexing and Slicing
-- Iterating over Data Structures
+- Function definition and invocation
+- Parameters, return values, and scope
+- Recursion basics
 
-### Module 4: Functions and Scope
+### Module 4: Data Structures
 
-- Defining and Calling Functions
-- Parameters and Return Values
-- Variable Scope
-- Recursion (basic examples)
+- Strings, lists, tuples, and dictionaries
+- Indexing, slicing, and iteration
 
-### Module 5: Object-Oriented Programming
+### Module 5: File Input/Output
 
-- Classes and Objects
-- Methods and Attributes
-- Inheritance and Encapsulation
+- Reading and writing text files
+- Exception handling
 
-### Module 6: Modules and Packages
+### Module 6: Testing and Debugging
 
-- Using Standard Library Modules
-- Creating Modules and Packages
-- Import Statements
+- Unit testing with `unittest`
+- Debugging and error types
+- Code style (PEP 8)
 
-### Module 7: File I/O
+### Module 7: Algorithmic Thinking
 
-- Reading and Writing Files
-- Working with CSV and Text Files
-
-### Module 8: Debugging and Testing
-
-- Debugging Techniques
-- Writing Unit Tests
-- Using Python’s `unittest` Module
-
-### Module 9: Algorithms and Complexity
-
-- Basic Searching and Sorting
-- Big O Notation Overview
-- Algorithm Analysis
-
----
+- Simple searching and sorting
+- Basic Big-O concepts
 
 ## References
 
-- Gries, P., Campbell, T., Montojo, J. – _Practical Programming: An Introduction to Computer Science Using Python 3_ (3rd ed), Pearson, 2013
-- Downey, A. – _Think Python: How to Think Like a Computer Scientist_ (2nd ed), O’Reilly Media, 2015
-
----
+- Gries P., Campbell J., & Montojo J. – _Practical Programming_ (3rd ed.) Pearson, 2013
+- Downey A. – _Think Python_ (2nd ed.) O’Reilly Media, 2015
 
 ## Assignments
 
-- **Assignment 1:** Thu Feb 3 — before 5:00 pm
-- **Assignment 2:** Thu Mar 10 — before 5:00 pm
-- **Assignment 3:** Thu Mar 31 — before 5:00 pm
-
----
+- **A1:** Basic Python
+- **A2:** Functions & File I/O
+- **A3:** Data Structures & Algorithms
 
 ## Marking Scheme
 
-- Prepare Exercises: **5%** (11 exercises; best 10 count; 0.5% each)
-- Perform Exercises: **20%** (11 exercises; best 10 count; 2% each)
-- Assignments: **28%** (A1 8%, A2 10%, A3 10%)
-- Research Activities: **2%** (complete all 4 to earn 2%)
-- Midterm Test: **15%**
-- Final Assessment: **30%**
-
----
-
-## PCRS: Prepare, Rehearse, Perform
-
-- **Prepare:** Watch lecture videos and complete short preparation exercises.
-- **Rehearse:** Practice during lecture time with instructor/TA support.
-- **Perform:** Complete graded Perform exercises using MarkUs.
-
----
-
-## Term Tests and Final Assessment
-
-- **Midterm Test:** Scheduled during the term (see course calendar).
-- **Final Assessment:** Scheduled in the final assessment period.
-
----
+- Labs 15 %
+- Assignments 35 %
+- Midterm 20 %
+- Final 30 %
 
 ## Academic Integrity
 
-All submitted work must be your own. Avoid using or sharing solutions from unauthorized sources. The department uses tools to detect similar code.
+All submitted work must be original.  
+Similarity checks will be used; discussion only is allowed.
 
----
+## Accessibility and Support
 
-## Accessibility Needs
+Students needing accommodations should contact  
+**Student Life | Accessibility Services** early in the semester.  
+Help is available via labs, tutorials, and the course forum.
 
-Students requiring accommodations should contact **Student Life | Accessibility Services** as soon as possible.
+## Special Considerations
 
----
-
-## Special Consideration
-
-If illness or an emergency prevents you from completing work, apply to the **Course Coordinator** via the special consideration process.
+Illness/emergency absences must be reported  
+through the course coordinator per UofT policy.

--- a/universities/university-of-toronto/computer-science/2022/s01/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/02.md
@@ -1,0 +1,68 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 1
+course_code: "CSC148H1"
+course_title: "introduction-to-computer-science"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn software design principles using Python
+2. Understand object-oriented programming concepts
+3. Analyze algorithmic complexity and recursion
+4. Develop modular, reusable, and maintainable code
+
+## Course Content
+
+### Module 1: Software Design Basics
+
+- Abstract data types (ADTs)
+- Encapsulation and interfaces
+- Object-oriented programming in Python
+
+### Module 2: Data Structures
+
+- Linked lists, stacks, queues
+- Trees and binary search trees
+- Recursion on trees
+
+### Module 3: Algorithm Analysis
+
+- Growth rates and Big-O notation
+- Searching and sorting algorithms
+
+### Module 4: Testing and Debugging
+
+- Unit testing and test-driven development
+- Assertions and invariants
+
+## References
+
+- Gries D., Gries P. – _CSC148 Course Notes_, University of Toronto
+- Downey A. – _Think Data Structures_, O’Reilly Media
+
+## Assignments
+
+- **A1:** Object-oriented design
+- **A2:** Recursion and trees
+- **A3:** Sorting and complexity
+
+## Marking Scheme
+
+- Labs 15 %
+- Assignments 35 %
+- Midterm 20 %
+- Final 30 %
+
+## Academic Integrity
+
+All code must be individual work. Use of AI tools or code reuse is prohibited.
+
+## Accessibility and Support
+
+Assistance via labs, tutorials, and Piazza/Quercus forum.

--- a/universities/university-of-toronto/computer-science/2022/s01/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/03.md
@@ -1,0 +1,51 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 1
+course_code: "CSC165H1"
+course_title: "mathematical-expression-and-reasoning-for-computer-science"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Develop logical and mathematical reasoning skills
+2. Learn proof techniques used in computer science
+3. Apply logic to analyze algorithms and programs
+
+## Course Content
+
+### Module 1: Logic and Propositional Reasoning
+
+- Propositions, predicates, and quantifiers
+- Logical equivalence and implication
+
+### Module 2: Proof Techniques
+
+- Direct, contrapositive, and contradiction proofs
+- Mathematical induction
+
+### Module 3: Algorithmic Analysis
+
+- Formal definition of Big-O, Ω, Θ
+- Proving complexity bounds
+
+### Module 4: Applications
+
+- Proofs in recursion and correctness
+- Discrete mathematical models
+
+## References
+
+- UofT Course Notes by Department of Computer Science
+- Rosen K. – _Discrete Mathematics and Its Applications_, McGraw-Hill
+
+## Marking Scheme
+
+- Tutorials 15 %
+- Assignments 30 %
+- Midterm 25 %
+- Final 30 %

--- a/universities/university-of-toronto/computer-science/2022/s01/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/04.md
@@ -1,0 +1,53 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 1
+course_code: "MAT137Y1"
+course_title: "calculus-i"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand fundamental concepts of single-variable calculus
+2. Learn to analyze functions and their limits, continuity, and derivatives
+3. Apply calculus concepts to problem solving and modeling
+
+## Course Content
+
+### Module 1: Functions and Limits
+
+- Review of functions and graphs
+- Limit concept and continuity
+
+### Module 2: Differentiation
+
+- Definition of the derivative
+- Rules of differentiation
+- Applications to rates of change and optimization
+
+### Module 3: Integration
+
+- Riemann sums and definite integral
+- Fundamental Theorem of Calculus
+- Applications to area and accumulation
+
+### Module 4: Series and Sequences
+
+- Convergence tests
+- Power series and Taylor series
+
+## References
+
+- Stewart J. – _Calculus: Early Transcendentals_, 8th ed. Cengage
+- UofT MAT137 Course Notes
+
+## Marking Scheme
+
+- Weekly Quizzes 15 %
+- Assignments 20 %
+- Midterm 30 %
+- Final 35 %

--- a/universities/university-of-toronto/computer-science/2022/s02/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s02/01.md
@@ -1,0 +1,74 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 2
+course_code: "CSC207H1"
+course_title: "software-design"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn principles of software design and object-oriented programming
+2. Build maintainable, modular, and reusable systems
+3. Apply version control and collaborative development workflows
+4. Understand testing, refactoring, and documentation best practices
+
+## Course Content
+
+### Module 1: Software Design Fundamentals
+
+- Design patterns, abstraction, interfaces
+- Object-oriented principles (SOLID)
+- UML diagrams and documentation
+
+### Module 2: Data Structures and Design Patterns
+
+- Lists, maps, sets, and trees in large projects
+- MVC and observer patterns
+
+### Module 3: Team Software Development
+
+- Git and GitHub workflows
+- Agile and Scrum methods
+
+### Module 4: Testing & Maintenance
+
+- Unit, integration, and system testing
+- Continuous integration and refactoring
+
+## References
+
+- _CSC207 Course Notes_, University of Toronto
+- Freeman & Freeman – _Head First Design Patterns_
+- Beck K. – _Test Driven Development: By Example_
+
+## Assignments
+
+- **A1:** Design and implement core modules
+- **A2:** Team project development
+- **A3:** Final software project
+
+## Marking Scheme
+
+- Labs 10 %
+- Assignments 45 %
+- Midterm 20 %
+- Final 25 %
+
+## Academic Integrity
+
+All code and documentation must be original.  
+Collaborative projects must follow team guidelines.
+
+## Accessibility and Support
+
+Assistance via labs, office hours, and Piazza.  
+Students needing accommodations should contact **Accessibility Services**.
+
+## Special Considerations
+
+Requests for extensions or absences handled via the **CS Undergraduate Office**.

--- a/universities/university-of-toronto/computer-science/2022/s02/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s02/02.md
@@ -1,0 +1,67 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 2
+course_code: "CSC209H1"
+course_title: "software-tools-and-systems-programming"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand Unix/Linux development environments and tools
+2. Develop proficiency in C programming
+3. Learn systems-level programming concepts: memory, processes, and files
+4. Use debugging and profiling tools effectively
+
+## Course Content
+
+### Module 1: Unix Tools and Environment
+
+- Command-line utilities, shell scripting
+- Makefiles, build automation, and Git
+
+### Module 2: C Programming Basics
+
+- Data types, pointers, arrays, and structures
+- Dynamic memory allocation
+
+### Module 3: Systems Programming
+
+- File I/O and system calls
+- Processes, signals, and inter-process communication
+
+### Module 4: Debugging and Performance
+
+- Using `gdb`, `valgrind`, and profiling tools
+- Memory management and optimization
+
+## References
+
+- _CSC209 Course Notes_, University of Toronto
+- Kernighan & Ritchie – _The C Programming Language_
+- Robbins & Beebe – _Unix in a Nutshell_
+
+## Assignments
+
+- **A1:** C programming basics
+- **A2:** File I/O and memory management
+- **A3:** System-level project
+
+## Marking Scheme
+
+- Labs 10 %
+- Assignments 40 %
+- Midterm 25 %
+- Final 25 %
+
+## Academic Integrity
+
+All submitted code must be written individually unless stated otherwise.
+
+## Accessibility and Support
+
+Help available through labs, tutorials, and online office hours.

--- a/universities/university-of-toronto/computer-science/2022/s02/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s02/03.md
@@ -1,0 +1,48 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 2
+course_code: "MAT223H1"
+course_title: "linear-algebra-i"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand vector spaces, linear transformations, and matrices
+2. Develop skills in solving systems of linear equations
+3. Apply linear algebra concepts to computer science and data
+
+## Course Content
+
+### Module 1: Vectors and Matrices
+
+- Systems of linear equations
+- Matrix operations and inverses
+
+### Module 2: Vector Spaces and Subspaces
+
+- Basis, dimension, and rank
+- Linear independence and span
+
+### Module 3: Eigenvalues and Eigenvectors
+
+- Diagonalization and applications
+
+### Module 4: Applications in CS
+
+- Graphs, transformations, and data representation
+
+## References
+
+- Lay D., Lay S., & McDonald J. – _Linear Algebra and Its Applications_ (6th ed.)
+- _MAT223 Course Notes_, UofT
+
+## Marking Scheme
+
+- Assignments 20 %
+- Midterm 30 %
+- Final 50 %

--- a/universities/university-of-toronto/computer-science/2022/s02/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s02/04.md
@@ -1,0 +1,54 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 2
+course_code: "STA247H1"
+course_title: "probability-with-computer-applications"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand probability theory fundamentals
+2. Apply probability to computer-science-related problems
+3. Use computational tools to simulate and analyze randomness
+
+## Course Content
+
+### Module 1: Basic Probability Concepts
+
+- Sample spaces, events, conditional probability
+- Bayes’ theorem and independence
+
+### Module 2: Random Variables and Distributions
+
+- Discrete and continuous random variables
+- Expectation, variance, and covariance
+
+### Module 3: Joint Distributions and Limit Theorems
+
+- Central limit theorem and law of large numbers
+
+### Module 4: Applications
+
+- Simulation using Python or R
+- Applications to algorithms, data science, and reliability
+
+## References
+
+- Ross S. – _A First Course in Probability_ (10th ed.)
+- _STA247 Course Notes_, UofT
+
+## Assignments
+
+- Problem sets & computational labs
+
+## Marking Scheme
+
+- Labs 15 %
+- Assignments 25 %
+- Midterm 25 %
+- Final 35 %

--- a/universities/university-of-toronto/computer-science/2022/s03/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s03/01.md
@@ -1,0 +1,56 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 3
+course_code: "CSC236H1"
+course_title: "introduction-to-the-theory-of-computation"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand formal reasoning techniques in computer science
+2. Learn recursive definitions and mathematical induction
+3. Analyze algorithm correctness and complexity
+4. Explore computability and limits of computation
+
+## Course Content
+
+### Module 1: Mathematical Proofs and Induction
+
+- Direct, contrapositive, and inductive proofs
+- Recursive definitions and structural induction
+
+### Module 2: Algorithmic Reasoning
+
+- Proving program correctness
+- Loop invariants and recursion correctness
+
+### Module 3: Asymptotic Analysis
+
+- Big O, Omega, and Theta notation
+- Comparing algorithm growth rates
+
+### Module 4: Computability
+
+- Finite automata and Turing machines (intro)
+
+## References
+
+- Heap D., Doerksen D. – _CSC236 Course Notes_, University of Toronto
+- Sipser M. – _Introduction to the Theory of Computation_ (3rd ed.)
+
+## Assignments
+
+- Weekly problem sets on proofs and recursion
+- Midterm and final exam
+
+## Marking Scheme
+
+- Exercises 10 %
+- Assignments 40 %
+- Midterm 20 %
+- Final 30 %

--- a/universities/university-of-toronto/computer-science/2022/s03/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s03/02.md
@@ -1,0 +1,56 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 3
+course_code: "CSC258H1"
+course_title: "computer-organization"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand how computers execute programs at the hardware level
+2. Learn assembly language and digital logic fundamentals
+3. Explore CPU design, memory, and instruction cycles
+
+## Course Content
+
+### Module 1: Digital Logic Basics
+
+- Binary, hexadecimal, and Boolean algebra
+- Logic gates, multiplexers, decoders
+
+### Module 2: Processor Architecture
+
+- CPU structure, instruction set, and datapath
+- Control unit and pipelining
+
+### Module 3: Assembly Programming
+
+- MIPS assembly
+- Memory management and stack operations
+
+### Module 4: Input/Output and Performance
+
+- Caches and memory hierarchy
+- I/O handling and performance evaluation
+
+## References
+
+- Patterson & Hennessy – _Computer Organization and Design MIPS Edition_
+- _CSC258 Course Notes_, University of Toronto
+
+## Assignments
+
+- Digital circuit design
+- Assembly programming labs
+
+## Marking Scheme
+
+- Labs 20 %
+- Assignments 25 %
+- Midterm 25 %
+- Final 30 %

--- a/universities/university-of-toronto/computer-science/2022/s03/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s03/03.md
@@ -1,0 +1,53 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 3
+course_code: "CSC263H1"
+course_title: "data-structures-and-analysis"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Analyze the efficiency of algorithms and data structures
+2. Implement and evaluate abstract data types
+3. Apply advanced techniques for performance optimization
+
+## Course Content
+
+### Module 1: Asymptotic Analysis
+
+- Time and space complexity
+- Big O, Ω, Θ notation
+
+### Module 2: Data Structures
+
+- Balanced binary search trees
+- Heaps, hash tables, and priority queues
+
+### Module 3: Graphs and Algorithms
+
+- Graph representations and traversal
+- Minimum spanning trees, Dijkstra’s algorithm
+
+### Module 4: Advanced Topics
+
+- Amortized analysis and disjoint sets
+
+## References
+
+- Goodrich, Tamassia & Goldwasser – _Data Structures and Algorithms in Python_
+- Cormen et al. – _Introduction to Algorithms (CLRS)_
+
+## Assignments
+
+- Implementation labs and performance analysis
+
+## Marking Scheme
+
+- Assignments 40 %
+- Midterm 20 %
+- Final 40 %

--- a/universities/university-of-toronto/computer-science/2022/s03/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s03/04.md
@@ -1,0 +1,54 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 3
+course_code: "CSC300H1"
+course_title: "computers-and-society"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Examine ethical, legal, and social issues in computing
+2. Understand privacy, security, and intellectual property concerns
+3. Analyze professional responsibilities of computer scientists
+
+## Course Content
+
+### Module 1: Ethics and Professionalism
+
+- Codes of conduct and responsibilities
+- Case studies in ethical decision-making
+
+### Module 2: Privacy and Security
+
+- Data protection, surveillance, and consent
+- Cybersecurity and digital rights
+
+### Module 3: Social Impact of Technology
+
+- AI and automation in society
+- Digital divide and accessibility
+
+### Module 4: Policy and Governance
+
+- Regulation, IP law, and open-source licensing
+
+## References
+
+- Johnson D. – _Computer Ethics_ (4th ed.)
+- _CSC300 Course Materials_, University of Toronto
+
+## Assignments
+
+- Reflection essays, group discussions, final paper
+
+## Marking Scheme
+
+- Participation 10 %
+- Assignments 40 %
+- Midterm 20 %
+- Final 30 %

--- a/universities/university-of-toronto/computer-science/2022/s04/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s04/01.md
@@ -1,0 +1,56 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 4
+course_code: "CSC209H1"
+course_title: "software-tools-and-systems-programming"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn systems-level programming concepts using C and Unix tools
+2. Develop understanding of processes, memory management, and file I/O
+3. Build efficient and maintainable software using Makefiles and debugging tools
+4. Apply shell scripting for automation and task management
+
+## Course Content
+
+### Module 1: Introduction to C Programming
+
+- Pointers, arrays, and strings
+- Dynamic memory allocation
+- Structs and function pointers
+
+### Module 2: Unix Tools and Environment
+
+- Shell scripting and command-line utilities
+- File permissions, processes, and signals
+
+### Module 3: Systems Programming
+
+- File I/O, pipes, and sockets
+- Concurrency and synchronization basics
+
+### Module 4: Software Engineering Tools
+
+- Makefiles, version control (Git), and debugging (gdb, valgrind)
+
+## References
+
+- Kernighan & Ritchie – _The C Programming Language_ (2nd ed.)
+- Robbins & Beebe – _Unix in a Nutshell_
+
+## Assignments
+
+- C programming projects and shell scripting exercises
+
+## Marking Scheme
+
+- Labs/Exercises: 20%
+- Assignments: 40%
+- Midterm: 15%
+- Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s04/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s04/02.md
@@ -1,0 +1,53 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 4
+course_code: "CSC265H1"
+course_title: "data-structures-and-analysis-ii"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Analyze and design advanced data structures and algorithms
+2. Implement efficient solutions to complex computational problems
+3. Understand amortized analysis and probabilistic methods
+
+## Course Content
+
+### Module 1: Advanced Trees
+
+- AVL and Red-Black Trees
+- B-Trees and Splay Trees
+
+### Module 2: Graph Algorithms
+
+- Network flow and matching
+- Strongly connected components
+
+### Module 3: Amortized Analysis
+
+- Potential and accounting methods
+- Disjoint set union-find
+
+### Module 4: Randomized Algorithms
+
+- Hashing and probabilistic analysis
+
+## References
+
+- Cormen et al. – _Introduction to Algorithms_ (CLRS, 3rd ed.)
+- Goodrich et al. – _Data Structures and Algorithms in Python_
+
+## Assignments
+
+- Implementation-based assignments and analytical problem sets
+
+## Marking Scheme
+
+- Assignments: 40%
+- Midterm: 20%
+- Final Exam: 40%

--- a/universities/university-of-toronto/computer-science/2022/s04/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s04/03.md
@@ -1,0 +1,54 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 4
+course_code: "CSC301H1"
+course_title: "introduction-to-software-engineering"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the software development lifecycle (SDLC)
+2. Apply design patterns and agile methodologies in team projects
+3. Learn project management, testing, and deployment best practices
+
+## Course Content
+
+### Module 1: Software Development Life Cycle
+
+- Requirements gathering and analysis
+- System design and documentation
+
+### Module 2: Software Design
+
+- UML diagrams, patterns, and architecture styles
+- Modularization and interface design
+
+### Module 3: Agile Development
+
+- Scrum, sprints, and user stories
+- Continuous integration and testing
+
+### Module 4: Project Implementation
+
+- Group project using Git, CI/CD pipelines, and version control
+
+## References
+
+- Sommerville, I. – _Software Engineering_ (10th ed.)
+- Pressman, R. – _Software Engineering: A Practitioner’s Approach_
+
+## Assignments
+
+- Group project: end-to-end software system design and development
+
+## Marking Scheme
+
+- Project Deliverables: 50%
+- Quizzes: 10%
+- Midterm: 15%
+- Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s04/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s04/04.md
@@ -1,0 +1,54 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 4
+course_code: "CSC373H1"
+course_title: "algorithm-design-analysis-and-complexity"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Master algorithm design paradigms such as divide-and-conquer, greedy, and dynamic programming
+2. Analyze time and space complexity rigorously
+3. Understand NP-completeness and approximation algorithms
+
+## Course Content
+
+### Module 1: Algorithm Design Techniques
+
+- Divide and conquer
+- Dynamic programming
+- Greedy algorithms
+
+### Module 2: Graph Algorithms
+
+- Shortest paths, MSTs, and flows
+- Network optimization
+
+### Module 3: Complexity Theory
+
+- NP, co-NP, and NP-completeness
+- Reductions and problem classification
+
+### Module 4: Approximation and Randomized Algorithms
+
+- Heuristics and probabilistic approaches
+
+## References
+
+- Kleinberg & Tardos – _Algorithm Design_
+- Cormen et al. – _Introduction to Algorithms (CLRS)_
+
+## Assignments
+
+- Analytical problem sets and coding exercises
+
+## Marking Scheme
+
+- Assignments: 40%
+- Midterm: 20%
+- Final Exam: 40%

--- a/universities/university-of-toronto/computer-science/2022/s05/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s05/01.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 5
+course_code: "CSC324H1"
+course_title: "principles-of-programming-languages"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand fundamental concepts underlying modern programming languages
+2. Explore paradigms such as functional, logical, and object-oriented programming
+3. Learn about interpreters, type systems, and language design trade-offs
+
+## Course Content
+
+### Module 1: Language Paradigms
+
+- Imperative vs Functional vs Declarative styles
+- Syntax and semantics
+
+### Module 2: Functional Programming
+
+- Higher-order functions, closures, recursion
+- Immutability and lazy evaluation
+
+### Module 3: Type Systems and Polymorphism
+
+- Static vs Dynamic typing
+- Type inference and generics
+
+### Module 4: Interpreters and Language Semantics
+
+- Parsing expressions and evaluation
+- Implementing mini interpreters
+
+## References
+
+- Sebesta — _Concepts of Programming Languages_ (12th ed.)
+- SICP — _Structure and Interpretation of Computer Programs_
+
+## Assignments
+
+- Interpreter implementation and language design tasks
+
+## Marking Scheme
+
+- Labs: 15% Assignments: 40% Midterm: 20% Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s05/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s05/02.md
@@ -1,0 +1,51 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 5
+course_code: "CSC343H1"
+course_title: "introduction-to-databases"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand database design principles and the relational model
+2. Learn SQL for data definition and manipulation
+3. Apply normalization and transaction concepts to ensure data integrity
+
+## Course Content
+
+### Module 1: Relational Model
+
+- Tables, keys, and constraints
+- Relational algebra and calculus
+
+### Module 2: SQL Programming
+
+- DDL, DML, and query optimization
+- Joins, views, and indexes
+
+### Module 3: Database Design
+
+- ER modeling and normalization (1NF – 3NF – BCNF)
+
+### Module 4: Transactions and Concurrency
+
+- ACID properties and locking mechanisms
+- Recovery and logging
+
+## References
+
+- Silberschatz et al. – _Database System Concepts_ (7th ed.)
+- Elmasri & Navathe – _Fundamentals of Database Systems_
+
+## Assignments
+
+- SQL queries, ER diagrams, mini-project
+
+## Marking Scheme
+
+- Assignments: 40% Midterm: 20% Final Exam: 40%

--- a/universities/university-of-toronto/computer-science/2022/s05/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s05/03.md
@@ -1,0 +1,51 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 5
+course_code: "CSC336H1"
+course_title: "numerical-methods"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn numerical approaches for linear algebra and differential equations
+2. Understand error propagation and stability in computations
+3. Implement algorithms for scientific and engineering applications
+
+## Course Content
+
+### Module 1: Floating-Point Arithmetic
+
+- Machine precision and error analysis
+
+### Module 2: Solving Linear Systems
+
+- Gaussian elimination and LU decomposition
+
+### Module 3: Interpolation and Approximation
+
+- Polynomial and spline interpolation
+
+### Module 4: Numerical Differentiation and Integration
+
+- Trapezoidal and Simpson’s rules
+
+### Module 5: Ordinary Differential Equations
+
+- Euler and Runge-Kutta methods
+
+## References
+
+- Burden & Faires – _Numerical Analysis_ (10th ed.)
+
+## Assignments
+
+- MATLAB/Python projects for numerical solutions
+
+## Marking Scheme
+
+- Labs: 15% Assignments: 35% Midterm: 20% Final Exam: 30%

--- a/universities/university-of-toronto/computer-science/2022/s05/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s05/04.md
@@ -1,0 +1,51 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 5
+course_code: "CSC384H1"
+course_title: "introduction-to-artificial-intelligence"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the core principles and methods of Artificial Intelligence
+2. Learn search, planning, and reasoning techniques
+3. Develop AI agents for problem solving and decision making
+
+## Course Content
+
+### Module 1: Search and Optimization
+
+- Uninformed and informed search (A\*, Greedy, DFS, BFS)
+- Constraint satisfaction problems
+
+### Module 2: Logic and Reasoning
+
+- Propositional and first-order logic
+- Inference and resolution
+
+### Module 3: Planning and Decision Making
+
+- Game trees and minimax
+- Markov decision processes and reinforcement learning
+
+### Module 4: Machine Learning Basics
+
+- Supervised and unsupervised learning overview
+
+## References
+
+- Russell & Norvig – _Artificial Intelligence: A Modern Approach_ (4th ed.)
+- Poole & Mackworth – _Artificial Intelligence Foundations of Computational Agents_
+
+## Assignments
+
+- AI agent implementation and search/planning projects
+
+## Marking Scheme
+
+- Labs: 10% Assignments: 40% Midterm: 20% Final Exam: 30%

--- a/universities/university-of-toronto/computer-science/2022/s06/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s06/01.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 6
+course_code: "CSC301H1"
+course_title: "introduction-to-software-engineering"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the principles and lifecycle of software engineering
+2. Learn agile and iterative development methodologies
+3. Design, implement, and test software systems collaboratively
+
+## Course Content
+
+### Module 1: Software Process Models
+
+- Waterfall, Agile, and Scrum frameworks
+- Requirement gathering and user stories
+
+### Module 2: Software Design
+
+- UML diagrams and design patterns
+- Architectural styles (MVC, layered)
+
+### Module 3: Software Development
+
+- Version control (Git), testing, and continuous integration
+- Code reviews and documentation standards
+
+### Module 4: Software Quality
+
+- Testing levels and automation
+- Code metrics and refactoring
+
+## References
+
+- Sommerville, I. — _Software Engineering_ (10th ed.)
+- Pressman, R. — _Software Engineering: A Practitioner’s Approach_
+
+## Assignments
+
+- Group project on software design and development
+
+## Marking Scheme
+
+- Project: 40% Assignments: 30% Midterm: 15% Final Exam: 15%

--- a/universities/university-of-toronto/computer-science/2022/s06/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s06/02.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 6
+course_code: "CSC372H1"
+course_title: "algorithm-design-and-analysis"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand key algorithm design techniques and complexity analysis
+2. Develop efficient algorithms for graph, string, and optimization problems
+3. Analyze algorithm performance using Big-O and asymptotic notation
+
+## Course Content
+
+### Module 1: Complexity and Recurrence
+
+- Asymptotic analysis and recurrence relations
+
+### Module 2: Divide and Conquer
+
+- Merge sort, quick sort, and matrix multiplication
+
+### Module 3: Dynamic Programming
+
+- Knapsack, LCS, matrix chain multiplication
+
+### Module 4: Greedy Algorithms
+
+- MST, Huffman coding, and scheduling
+
+### Module 5: Graph Algorithms
+
+- BFS, DFS, shortest paths (Dijkstra, Bellman-Ford), and network flow
+
+## References
+
+- Cormen et al. — _Introduction to Algorithms_ (4th ed.)
+- Kleinberg & Tardos — _Algorithm Design_
+
+## Assignments
+
+- Algorithm design problems and coding challenges
+
+## Marking Scheme
+
+- Assignments: 40% Midterm: 25% Final Exam: 35%

--- a/universities/university-of-toronto/computer-science/2022/s06/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s06/03.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 6
+course_code: "CSC373H1"
+course_title: "operating-systems"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the structure and components of modern operating systems
+2. Learn process management, memory management, and file systems
+3. Implement system-level programs and simulations
+
+## Course Content
+
+### Module 1: Introduction and Processes
+
+- System calls, process states, and scheduling
+
+### Module 2: Concurrency and Synchronization
+
+- Threads, semaphores, mutexes, and monitors
+
+### Module 3: Memory Management
+
+- Paging, segmentation, and virtual memory
+
+### Module 4: File Systems and I/O
+
+- File organization, directories, and buffering
+
+### Module 5: Security and Protection
+
+- Access control and privilege management
+
+## References
+
+- Silberschatz et al. — _Operating System Concepts_ (10th ed.)
+- Tanenbaum & Bos — _Modern Operating Systems_
+
+## Assignments
+
+- C/Python programming for process and memory simulation
+
+## Marking Scheme
+
+- Labs: 20% Assignments: 35% Midterm: 20% Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s06/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s06/04.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 6
+course_code: "CSC358H1"
+course_title: "computer-networks"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn fundamental principles of computer networking and protocols
+2. Understand layered architectures and internetworking concepts
+3. Develop the ability to analyze and troubleshoot network performance
+
+## Course Content
+
+### Module 1: Network Basics
+
+- OSI and TCP/IP models
+- Data transmission and multiplexing
+
+### Module 2: Data Link Layer
+
+- Error detection, ARQ, and Ethernet
+
+### Module 3: Network Layer
+
+- IP addressing, routing algorithms, and subnetting
+
+### Module 4: Transport Layer
+
+- TCP, UDP, congestion control
+
+### Module 5: Application Layer
+
+- HTTP, DNS, SMTP, and socket programming
+
+## References
+
+- Kurose & Ross — _Computer Networking: A Top-Down Approach_ (8th ed.)
+
+## Assignments
+
+- Socket programming and protocol simulation
+
+## Marking Scheme
+
+- Labs: 20% Assignments: 30% Midterm: 25% Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s07/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s07/01.md
@@ -1,0 +1,57 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 7
+course_code: "CSC384H1"
+course_title: "artificial-intelligence"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand fundamental concepts and problems in Artificial Intelligence (AI).
+2. Learn key AI algorithms for search, reasoning, and decision-making.
+3. Apply AI techniques to problem-solving in real-world scenarios.
+
+## Course Content
+
+### Module 1: Introduction to AI
+
+- History and overview of AI
+- Intelligent agents and environments
+
+### Module 2: Search Algorithms
+
+- Uninformed and informed search
+- A\*, greedy, and heuristic-based search
+
+### Module 3: Knowledge Representation
+
+- Propositional and first-order logic
+- Inference and unification
+
+### Module 4: Planning and Reasoning
+
+- Goal-based planning
+- Constraint satisfaction problems (CSPs)
+
+### Module 5: Machine Learning Basics
+
+- Supervised learning concepts
+- Decision trees and k-nearest neighbors
+
+## References
+
+- Russell & Norvig — _Artificial Intelligence: A Modern Approach_ (4th ed.)
+- Poole & Mackworth — _Artificial Intelligence: Foundations of Computational Agents_
+
+## Assignments
+
+- AI problem-solving and algorithm implementation
+
+## Marking Scheme
+
+- Assignments: 40% Midterm: 25% Final Exam: 35%

--- a/universities/university-of-toronto/computer-science/2022/s07/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s07/02.md
@@ -1,0 +1,52 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 7
+course_code: "CSC311H1"
+course_title: "machine-learning-and-data-mining"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the mathematical foundations of machine learning.
+2. Implement supervised and unsupervised learning algorithms.
+3. Evaluate model performance using statistical metrics.
+
+## Course Content
+
+### Module 1: Introduction
+
+- ML pipeline, training vs testing, generalization
+
+### Module 2: Supervised Learning
+
+- Linear regression, logistic regression, SVMs
+
+### Module 3: Neural Networks
+
+- Feedforward networks, backpropagation, regularization
+
+### Module 4: Unsupervised Learning
+
+- Clustering (k-means, hierarchical), PCA
+
+### Module 5: Evaluation and Applications
+
+- Cross-validation, overfitting, bias-variance tradeoff
+
+## References
+
+- Bishop — _Pattern Recognition and Machine Learning_
+- Hastie, Tibshirani & Friedman — _The Elements of Statistical Learning_
+
+## Assignments
+
+- Python-based ML projects and Kaggle-style tasks
+
+## Marking Scheme
+
+- Assignments: 50% Midterm: 20% Final Project/Exam: 30%

--- a/universities/university-of-toronto/computer-science/2022/s07/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s07/03.md
@@ -1,0 +1,51 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 7
+course_code: "CSC401H1"
+course_title: "natural-language-computing"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn the foundations of natural language processing (NLP).
+2. Implement text-processing pipelines and language models.
+3. Explore applications like sentiment analysis and translation.
+
+## Course Content
+
+### Module 1: Introduction to NLP
+
+- Language structure, corpora, and preprocessing
+
+### Module 2: Text Processing
+
+- Tokenization, stemming, lemmatization, and POS tagging
+
+### Module 3: Language Models
+
+- N-grams, smoothing, and probability estimation
+
+### Module 4: Parsing and Syntax
+
+- Context-free grammars and dependency parsing
+
+### Module 5: Deep Learning for NLP
+
+- Word embeddings, RNNs, and Transformers
+
+## References
+
+- Jurafsky & Martin — _Speech and Language Processing_ (3rd ed.)
+
+## Assignments
+
+- NLP programming projects and text analysis tasks
+
+## Marking Scheme
+
+- Assignments: 40% Project: 30% Midterm: 15% Final Exam: 15%

--- a/universities/university-of-toronto/computer-science/2022/s07/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s07/04.md
@@ -1,0 +1,55 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 7
+course_code: "CSC469H1"
+course_title: "parallel-and-distributed-systems"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand concepts of concurrency, parallelism, and distributed computation.
+2. Learn synchronization, communication, and consistency mechanisms.
+3. Design efficient parallel programs using modern frameworks.
+
+## Course Content
+
+### Module 1: Introduction
+
+- Motivation for parallel and distributed systems
+- Shared memory vs message passing
+
+### Module 2: Concurrency Control
+
+- Threads, synchronization, and locks
+- Deadlocks and race conditions
+
+### Module 3: Distributed Communication
+
+- RPC, sockets, and message queues
+- Fault tolerance and consensus
+
+### Module 4: Parallel Algorithms
+
+- MapReduce, OpenMP, and MPI basics
+
+### Module 5: Performance and Scalability
+
+- Load balancing and bottleneck analysis
+
+## References
+
+- Coulouris, Dollimore, & Kindberg — _Distributed Systems: Concepts and Design_
+- Tanenbaum & Van Steen — _Distributed Systems: Principles and Paradigms_
+
+## Assignments
+
+- Parallel program design and distributed computation tasks
+
+## Marking Scheme
+
+- Labs: 20% Assignments: 30% Midterm: 25% Final Exam: 25%

--- a/universities/university-of-toronto/computer-science/2022/s08/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s08/01.md
@@ -1,0 +1,55 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 8
+course_code: "CSC494H1"
+course_title: "capstone-design-project"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Integrate theoretical and practical knowledge to design real-world software systems.
+2. Apply project management, teamwork, and software engineering principles.
+3. Demonstrate critical thinking, communication, and technical reporting skills.
+
+## Course Content
+
+### Module 1: Project Planning and Proposal
+
+- Project selection, scope definition, and feasibility
+- Requirement analysis and technical specifications
+
+### Module 2: System Design
+
+- Architectural design and system modeling
+- UI/UX design and database planning
+
+### Module 3: Implementation
+
+- Agile development and version control (Git)
+- Testing, validation, and documentation
+
+### Module 4: Deployment and Presentation
+
+- Deployment pipelines and demonstration
+- Final presentation and project defense
+
+## References
+
+- Sommerville, I. – _Software Engineering_ (10th ed.)
+- Pressman, R. – _Software Engineering: A Practitioner’s Approach_
+
+## Assessment
+
+- Proposal & Design Review: 20%
+- Implementation Milestones: 40%
+- Final Presentation & Report: 40%
+
+## Notes
+
+- Work in small teams under faculty supervision.
+- Deliverables include a working prototype and documentation.

--- a/universities/university-of-toronto/computer-science/2022/s08/02.md
+++ b/universities/university-of-toronto/computer-science/2022/s08/02.md
@@ -1,0 +1,48 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 8
+course_code: "CSC420H1"
+course_title: "introduction-to-image-understanding"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand the principles of image processing and computer vision.
+2. Implement algorithms for feature detection, classification, and object recognition.
+3. Explore modern deep learning approaches for vision tasks.
+
+## Course Content
+
+### Module 1: Image Fundamentals
+
+- Image representation, filtering, and transformation
+
+### Module 2: Feature Extraction
+
+- Edges, corners, SIFT, and HOG features
+
+### Module 3: Object Detection and Tracking
+
+- Classification, recognition, and tracking algorithms
+
+### Module 4: Deep Learning for Vision
+
+- CNN architectures, transfer learning, and applications
+
+## References
+
+- Szeliski, R. – _Computer Vision: Algorithms and Applications_
+- Forsyth & Ponce – _Computer Vision: A Modern Approach_
+
+## Assignments
+
+- Python + OpenCV lab tasks and vision projects
+
+## Marking Scheme
+
+- Assignments: 40% Midterm: 25% Final Project: 35%

--- a/universities/university-of-toronto/computer-science/2022/s08/03.md
+++ b/universities/university-of-toronto/computer-science/2022/s08/03.md
@@ -1,0 +1,53 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 8
+course_code: "CSC486H1"
+course_title: "principles-of-compiler-design"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Learn the structure and functioning of compilers.
+2. Implement lexical analysis, parsing, and code generation.
+3. Understand optimization techniques and runtime environments.
+
+## Course Content
+
+### Module 1: Introduction
+
+- Compiler phases and architecture
+- Source-to-source and target code generation
+
+### Module 2: Lexical and Syntax Analysis
+
+- Regular expressions and finite automata
+- LL and LR parsing techniques
+
+### Module 3: Semantic Analysis
+
+- Symbol tables, type checking, and scopes
+
+### Module 4: Intermediate Code Generation
+
+- Syntax-directed translation and intermediate representations
+
+### Module 5: Code Optimization and Generation
+
+- Peephole optimization and register allocation
+
+## References
+
+- Aho, Lam, Sethi, & Ullman – _Compilers: Principles, Techniques, and Tools_ (Dragon Book)
+
+## Assignments
+
+- Build a simple compiler or interpreter
+
+## Marking Scheme
+
+- Assignments: 40% Midterm: 30% Final Exam: 30%

--- a/universities/university-of-toronto/computer-science/2022/s08/04.md
+++ b/universities/university-of-toronto/computer-science/2022/s08/04.md
@@ -1,0 +1,54 @@
+---
+country: "canada"
+university: "university-of-toronto"
+branch: "computer-science"
+scheme: "2022"
+semester: 8
+course_code: "CSC458H1"
+course_title: "computer-networks"
+language: "english"
+contributor: "@joshna12"
+---
+
+## Course Objectives
+
+1. Understand network architecture and Internet protocols.
+2. Learn about data transmission, routing, and congestion control.
+3. Implement network programming and socket communication.
+
+## Course Content
+
+### Module 1: Networking Basics
+
+- OSI and TCP/IP models
+- Physical and data link layers
+
+### Module 2: Network Layer
+
+- IP addressing, routing, and forwarding
+
+### Module 3: Transport Layer
+
+- UDP, TCP, reliability, and congestion control
+
+### Module 4: Application Layer
+
+- DNS, HTTP, SMTP, and modern Internet services
+
+### Module 5: Network Security
+
+- Firewalls, encryption, and secure communication
+
+## References
+
+- Kurose & Ross — _Computer Networking: A Top-Down Approach_ (8th ed.)
+- Tanenbaum — _Computer Networks_ (5th ed.)
+
+## Assignments
+
+- Packet capture and analysis with Wireshark
+- Socket programming in Python/C
+
+## Marking Scheme
+
+- Labs: 20% Assignments: 35% Midterm: 20% Final Exam: 25%


### PR DESCRIPTION
Added CSC108H1 syllabus for University of Toronto (Canada), 2022 Semester 1.

Related issue: #132
Contributor: @joshna12
