### PR TITLE
add IIST Aerospace Engineering Semester 5 syllabus

### DIFF
--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/01.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/01.md
@@ -4,66 +4,69 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ma301c"
-course_title: "numerical-methods-and-optimization"
+course_code: "ma311h"
+course_title: "probability-and-statistics"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ma301c: numerical-methods-and-optimization
-  - (MA301C: Numerical Methods and Optimization)
+# ma311h: probability-and-statistics
+  - (MA311H: Probability and Statistics)
 
 ## Course Objectives
-* To introduce numerical techniques for solving algebraic and differential equations.  
-* To develop computational skills for interpolation, curve fitting, and numerical integration.  
-* To understand optimization principles and apply them to engineering problems.  
-* To prepare students for numerical simulation and analysis in aerospace applications.  
+* To understand fundamental concepts of probability theory
+* To study random variables and their distributions
+* To learn moment generating functions and multivariate distributions
+* To understand statistical inference and hypothesis testing
+* To apply regression analysis and statistical quality control
 
 ## Course Content
 
-### Module 1: Solutions of Equations
-* Solution of nonlinear equations – bisection, false position, Newton–Raphson methods.  
-* Systems of linear equations – Gauss elimination, LU decomposition.  
-* Iterative methods – Jacobi and Gauss–Seidel.  
-* Error analysis and convergence criteria.  
+### Module 1: Probability Fundamentals
+* Elementary concepts on probability
+* Axiomatic definition of probability
+* Conditional probability and Bayes' theorem
+* Random variables concepts
+* Standard discrete and continuous distributions
 
-### Module 2: Interpolation and Curve Fitting
-* Finite differences – forward, backward, and central.  
-* Newton’s forward and backward interpolation formulae.  
-* Lagrange’s interpolation formula.  
-* Least-squares curve fitting – straight line and polynomial.  
-* Applications in data analysis and aerodynamic curve generation.  
+### Module 2: Moments and Multivariate Distributions
+* Moments of random variables
+* Moment generating functions
+* Multivariate random variables
+* Joint distributions of random variables
+* Conditional and marginal distributions
 
-### Module 3: Numerical Differentiation and Integration
-* Numerical differentiation using finite differences.  
-* Newton–Cotes quadrature formulae.  
-* Trapezoidal and Simpson’s rules.  
-* Romberg integration.  
-* Applications to engineering integrals in fluid flow and thermal systems.  
+### Module 3: Advanced Probability Theory
+* Conditional expectation concepts
+* Distributions of functions of random variables
+* t and χ² distributions
+* Schwartz and Chebyshev inequalities
+* Limit theorems and central limit theorem
 
-### Module 4: Numerical Solution of Differential Equations
-* Euler and modified Euler methods.  
-* Runge–Kutta methods (2nd and 4th order).  
-* Numerical solution of simultaneous ODEs.  
-* Finite difference methods for boundary-value problems.  
-* Applications in trajectory and structural simulations.  
+### Module 4: Statistical Inference
+* Elementary concepts on populations, samples, statistics
+* Sampling distributions of sample mean and sample variance
+* Point estimators and their properties
+* Confidence interval for sample mean
+* Tests of hypotheses
 
-### Module 5: Optimization Techniques
-* Introduction to optimization problems.  
-* Unconstrained optimization – single and multivariable.  
-* Constrained optimization – Lagrange multipliers.  
-* Linear programming – simplex method (basics).  
-* Applications of optimization in aerospace design.  
+### Module 5: Applied Statistics
+* Chi-squared test of goodness of fit
+* Simple linear regression and correlation
+* Curve fitting techniques
+* Inferences concerning regression coefficients
+* Statistical quality control methods
 
 ---
 
 ## References
 
 ### Text Books
-* Chapra, S. C. and Canale, R. P. – *Numerical Methods for Engineers*, 8th ed., McGraw-Hill (2020).  
-* Rao, S. S. – *Engineering Optimization: Theory and Practice*, 4th ed., Wiley (2009).  
+* Walpole, W. E., Myers, R. H., Myers, S. L., and Ye, K. - *Probability & Statistics for Engineers & Scientists*, 9th ed., Pearson Education (2012)
 
 ### References
-* Jain, M. K., Iyengar, S. R. K., and Jain, R. K. – *Numerical Methods for Scientific and Engineering Computation*, 6th ed., New Age (2012).  
-* Burden, R. L. and Faires, J. D. – *Numerical Analysis*, 10th ed., Cengage (2015).  
-* Taha, H. A. – *Operations Research: An Introduction*, 10th ed., Pearson (2017).  
+* Johnson, R. A. - *Miller & Freund's Probability and Statistics for Engineers*, 6th ed., Prentice Hall (2000)
+* Milton, J. S. and Arnold, J. C. - *Introduction to Probability and Statistics: Principles and Applications for Engineering and the Computing Sciences*, 4th ed., McGraw-Hill (2002)
+* Ross, S. M. - *Introduction to Probability and Statistics for Engineers and Scientists*, 3rd ed., Academic Press (2004)
+* Hogg, R. V. and Tanis, E. A. - *Probability and Statistical Inference*, 7th ed., Prentice Hall (2005)
+* Larsen, R. J. and Marx, M. L. - *An Introduction to Mathematical Statistics and Its Applications*, 4th ed., Prentice Hall (2005)

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/01.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/01.md
@@ -1,0 +1,69 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ma301c"
+course_title: "numerical-methods-and-optimization"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ma301c: numerical-methods-and-optimization
+  - (MA301C: Numerical Methods and Optimization)
+
+## Course Objectives
+* To introduce numerical techniques for solving algebraic and differential equations.  
+* To develop computational skills for interpolation, curve fitting, and numerical integration.  
+* To understand optimization principles and apply them to engineering problems.  
+* To prepare students for numerical simulation and analysis in aerospace applications.  
+
+## Course Content
+
+### Module 1: Solutions of Equations
+* Solution of nonlinear equations – bisection, false position, Newton–Raphson methods.  
+* Systems of linear equations – Gauss elimination, LU decomposition.  
+* Iterative methods – Jacobi and Gauss–Seidel.  
+* Error analysis and convergence criteria.  
+
+### Module 2: Interpolation and Curve Fitting
+* Finite differences – forward, backward, and central.  
+* Newton’s forward and backward interpolation formulae.  
+* Lagrange’s interpolation formula.  
+* Least-squares curve fitting – straight line and polynomial.  
+* Applications in data analysis and aerodynamic curve generation.  
+
+### Module 3: Numerical Differentiation and Integration
+* Numerical differentiation using finite differences.  
+* Newton–Cotes quadrature formulae.  
+* Trapezoidal and Simpson’s rules.  
+* Romberg integration.  
+* Applications to engineering integrals in fluid flow and thermal systems.  
+
+### Module 4: Numerical Solution of Differential Equations
+* Euler and modified Euler methods.  
+* Runge–Kutta methods (2nd and 4th order).  
+* Numerical solution of simultaneous ODEs.  
+* Finite difference methods for boundary-value problems.  
+* Applications in trajectory and structural simulations.  
+
+### Module 5: Optimization Techniques
+* Introduction to optimization problems.  
+* Unconstrained optimization – single and multivariable.  
+* Constrained optimization – Lagrange multipliers.  
+* Linear programming – simplex method (basics).  
+* Applications of optimization in aerospace design.  
+
+---
+
+## References
+
+### Text Books
+* Chapra, S. C. and Canale, R. P. – *Numerical Methods for Engineers*, 8th ed., McGraw-Hill (2020).  
+* Rao, S. S. – *Engineering Optimization: Theory and Practice*, 4th ed., Wiley (2009).  
+
+### References
+* Jain, M. K., Iyengar, S. R. K., and Jain, R. K. – *Numerical Methods for Scientific and Engineering Computation*, 6th ed., New Age (2012).  
+* Burden, R. L. and Faires, J. D. – *Numerical Analysis*, 10th ed., Cengage (2015).  
+* Taha, H. A. – *Operations Research: An Introduction*, 10th ed., Pearson (2017).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/02.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/02.md
@@ -4,67 +4,73 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ae301c"
-course_title: "compressible-aerodynamics"
+course_code: "ae311c"
+course_title: "spaceflight-mechanics"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ae301c: compressible-aerodynamics
-  - (AE301C: Compressible Aerodynamics)
+# ae311c: spaceflight-mechanics
+  - (AE311C: Spaceflight Mechanics)
 
 ## Course Objectives
-* To introduce the fundamental principles of compressible flow and high-speed aerodynamics.  
-* To study isentropic flow, normal and oblique shocks, and their applications.  
-* To understand the behaviour of nozzles, diffusers, and high-speed aerodynamic devices.  
-* To apply compressible flow analysis to aerospace propulsion and aerodynamic design.  
+* To understand dynamics of point masses and Newton's laws
+* To study Kepler's laws and orbital mechanics
+* To analyze orbits in three dimensions and coordinate transformations
+* To learn orbit determination and maneuver techniques
+* To examine lunar transfer trajectories and advanced orbital concepts
 
 ## Course Content
 
-### Module 1: Fundamentals of Compressible Flow
-* Definition of compressibility and compressible flow regimes.  
-* Speed of sound and Mach number.  
-* Stagnation properties and isentropic relations.  
-* Introduction to area–velocity relation.  
-* Applications in nozzles, diffusers, and high-speed systems.  
+### Module 1: Fundamental Orbital Mechanics
+* Dynamics of point masses
+* Newton's inverse square law applications
+* n-body equation formulation
+* Kepler's laws derivation and applications
+* Equation of conic sections and types
 
-### Module 2: One-Dimensional Isentropic Flow
-* Isentropic flow through variable-area ducts.  
-* Choked flow and critical conditions.  
-* Area–Mach number relation.  
-* Flow in convergent and convergent–divergent nozzles.  
-* Applications in propulsion and high-speed wind tunnels.  
+### Module 2: Orbital Parameters and Energy
+* Flight path angle calculations
+* Vis-Viva equation applications
+* Orbital position as a function of time
+* Kepler's equation solutions
+* Energy relationships in orbits
 
-### Module 3: Normal Shocks
-* Conservation equations across a shock.  
-* Normal shock relations – pressure, temperature, density, Mach number.  
-* Stagnation property changes across shocks.  
-* Fanno flow and Rayleigh flow fundamentals.  
-* Applications in supersonic intakes and propulsion devices.  
+### Module 3: Three-Dimensional Orbits
+* Orbits in three dimensions analysis
+* Different coordinate frames in astrodynamics
+* Conversion of state vector to orbital elements
+* Coordinate transformation between frames
+* Earth's oblateness effects
 
-### Module 4: Oblique Shocks and Expansion Waves
-* Oblique shock theory – θ–β–M relation.  
-* Shock polar and shock wave interactions.  
-* Prandtl–Meyer expansion waves.  
-* Supersonic flow past wedges and cones.  
-* Application in supersonic airfoils and high-speed vehicles.  
+### Module 4: Orbit Determination and Ground Tracks
+* Ground tracks calculation and analysis
+* Preliminary orbit determination methods
+* Julian date calculations
+* Topocentric coordinate frame
+* Angle and range measurements
 
-### Module 5: Compressible Flow Applications
-* High-speed wind tunnels – operation and instrumentation.  
-* Supersonic and hypersonic flows (overview).  
-* Shock–boundary layer interaction.  
-* Design considerations for supersonic inlets and nozzles.  
-* Computational methods in compressible aerodynamics (intro).  
+### Module 5: Orbital Maneuvers and Transfers
+* Orbit maneuvers principles
+* Impulse transfer techniques
+* Hohmann and bi-elliptic transfers
+* Phasing maneuvers and non-Hohman transfers
+* Plane change maneuvers and lunar transfer trajectories
 
 ---
 
 ## References
 
 ### Text Books
-* Anderson, J. D. – *Modern Compressible Flow: With Historical Perspective*, 3rd ed., McGraw-Hill (2002).  
-* Shapiro, A. H. – *The Dynamics and Thermodynamics of Compressible Fluid Flow*, Vol. I, Ronald Press (1953).  
+* Howard D. Curtis - *Orbital Mechanics for Engineering Students*, ELSEVIER
 
 ### References
-* Liepmann, H. W. and Roshko, A. – *Elements of Gasdynamics*, Dover Publications (2001).  
-* Zucrow, M. J. and Hoffman, J. D. – *Gas Dynamics*, Vol. I & II, Wiley (1976).  
-* Thompson, P. A. – *Compressible Fluid Dynamics*, McGraw-Hill (1972).  
+* Francis J Hale - *Introduction to Space Flight*, Prentice Hall
+* Ashish Tewari - *Atmospheric and Spaceflight Dynamics*, Birkhauser (2007)
+* David A Vallado - *Fundamentals of Astrodynamics and Applications*, Kluwer Academic Publishers
+* Richard H. Bartin - *An introduction to the Mathematics and Methods of Astrodynamics, Revised Edition*, AIAA Education Series
+* V A Chobotov - *ORBITAL MECHANICS*, AIAA EDUCATION SERIES
+* W E Weisel - *Spaceflight dynamics*, The McGraw-Hill Companies
+* Charles D. Brown - *Spacecraft Mission Design*, AIAA Education Series
+* P.R. Escobal - *Methods of Orbit determination*, Krieger Publishing Company
+* Michael D Griffin, James R French - *Space Vehicle Design*, AIAA Education Series

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/02.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/02.md
@@ -1,0 +1,70 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae301c"
+course_title: "compressible-aerodynamics"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae301c: compressible-aerodynamics
+  - (AE301C: Compressible Aerodynamics)
+
+## Course Objectives
+* To introduce the fundamental principles of compressible flow and high-speed aerodynamics.  
+* To study isentropic flow, normal and oblique shocks, and their applications.  
+* To understand the behaviour of nozzles, diffusers, and high-speed aerodynamic devices.  
+* To apply compressible flow analysis to aerospace propulsion and aerodynamic design.  
+
+## Course Content
+
+### Module 1: Fundamentals of Compressible Flow
+* Definition of compressibility and compressible flow regimes.  
+* Speed of sound and Mach number.  
+* Stagnation properties and isentropic relations.  
+* Introduction to area–velocity relation.  
+* Applications in nozzles, diffusers, and high-speed systems.  
+
+### Module 2: One-Dimensional Isentropic Flow
+* Isentropic flow through variable-area ducts.  
+* Choked flow and critical conditions.  
+* Area–Mach number relation.  
+* Flow in convergent and convergent–divergent nozzles.  
+* Applications in propulsion and high-speed wind tunnels.  
+
+### Module 3: Normal Shocks
+* Conservation equations across a shock.  
+* Normal shock relations – pressure, temperature, density, Mach number.  
+* Stagnation property changes across shocks.  
+* Fanno flow and Rayleigh flow fundamentals.  
+* Applications in supersonic intakes and propulsion devices.  
+
+### Module 4: Oblique Shocks and Expansion Waves
+* Oblique shock theory – θ–β–M relation.  
+* Shock polar and shock wave interactions.  
+* Prandtl–Meyer expansion waves.  
+* Supersonic flow past wedges and cones.  
+* Application in supersonic airfoils and high-speed vehicles.  
+
+### Module 5: Compressible Flow Applications
+* High-speed wind tunnels – operation and instrumentation.  
+* Supersonic and hypersonic flows (overview).  
+* Shock–boundary layer interaction.  
+* Design considerations for supersonic inlets and nozzles.  
+* Computational methods in compressible aerodynamics (intro).  
+
+---
+
+## References
+
+### Text Books
+* Anderson, J. D. – *Modern Compressible Flow: With Historical Perspective*, 3rd ed., McGraw-Hill (2002).  
+* Shapiro, A. H. – *The Dynamics and Thermodynamics of Compressible Fluid Flow*, Vol. I, Ronald Press (1953).  
+
+### References
+* Liepmann, H. W. and Roshko, A. – *Elements of Gasdynamics*, Dover Publications (2001).  
+* Zucrow, M. J. and Hoffman, J. D. – *Gas Dynamics*, Vol. I & II, Wiley (1976).  
+* Thompson, P. A. – *Compressible Fluid Dynamics*, McGraw-Hill (1972).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/03.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/03.md
@@ -1,0 +1,71 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae302c"
+course_title: "aerospace-structures-ii"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae302c: aerospace-structures-ii
+  - (AE302C: Aerospace Structures II)
+
+## Course Objectives
+* To extend the principles of solid mechanics to advanced aerospace structural components.  
+* To study shear flow, torsion, and bending in thin-walled members.  
+* To introduce energy methods and structural stability concepts.  
+* To prepare students for aircraft structural design and analysis applications.  
+
+## Course Content
+
+### Module 1: Stress and Strain Analysis
+* Plane stress and plane strain.  
+* Stress transformation and Mohr’s circle.  
+* Strain transformation and strain–displacement relations.  
+* Generalized Hooke’s law.  
+* Applications to aerospace structural elements.  
+
+### Module 2: Shear Flow in Thin-Walled Structures
+* Shear stresses in thin-walled open sections.  
+* Shear flow in multicell structures.  
+* Shear center determination for common sections.  
+* Applications to wing and fuselage structural design.  
+* Semi-monocoque construction.  
+
+### Module 3: Torsion of Thin-Walled Beams
+* Torsion of closed thin-walled tubes.  
+* Torsion of open sections and warping effects.  
+* Bredt–Batho theory for shear flow in closed sections.  
+* Multi-cell torsion analysis.  
+* Applications in aircraft structural components.  
+
+### Module 4: Energy Methods and Deflection Analysis
+* Strain energy and complementary energy.  
+* Castigliano’s theorems and applications.  
+* Unit load method.  
+* Deflection of beams and frames.  
+* Energy approach in structural analysis.  
+
+### Module 5: Buckling and Stability
+* Euler buckling of columns.  
+* Inelastic buckling (introduction).  
+* Local buckling of thin-walled members.  
+* Stability of structural components under compression and shear.  
+* Aerospace applications in wing spars, ribs, and fuselage frames.  
+
+---
+
+## References
+
+### Text Books
+* Megson, T. H. G. – *Aircraft Structures for Engineering Students*, 6th ed., Butterworth-Heinemann (2017).  
+* Timoshenko, S. P. and Gere, J. M. – *Theory of Elastic Stability*, McGraw-Hill (1961).  
+
+### References
+* Bruhn, E. F. – *Analysis and Design of Flight Vehicle Structures*, Tri-State Offset (1973).  
+* Niu, M. C. Y. – *Airframe Structural Design*, Conmilit Press (1999).  
+* Peery, D. J. and Azar, J. J. – *Aircraft Structures*, McGraw-Hill (1982).  
+* Ugural, A. C. – *Stresses in Plates and Shells*, McGraw-Hill (2004).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/03.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/03.md
@@ -4,68 +4,73 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ae302c"
-course_title: "aerospace-structures-ii"
+course_code: "ae312h"
+course_title: "computational-methods-in-engineering"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ae302c: aerospace-structures-ii
-  - (AE302C: Aerospace Structures II)
+# ae312h: computational-methods-in-engineering
+  - (AE312H: Computational Methods in Engineering)
 
 ## Course Objectives
-* To extend the principles of solid mechanics to advanced aerospace structural components.  
-* To study shear flow, torsion, and bending in thin-walled members.  
-* To introduce energy methods and structural stability concepts.  
-* To prepare students for aircraft structural design and analysis applications.  
+* To understand approximation and error analysis in numerical methods
+* To study roots of equations and algebraic equations solutions
+* To learn optimization techniques and curve fitting methods
+* To analyze numerical differentiation and integration
+* To solve ordinary differential equations numerically
 
 ## Course Content
 
-### Module 1: Stress and Strain Analysis
-* Plane stress and plane strain.  
-* Stress transformation and Mohr’s circle.  
-* Strain transformation and strain–displacement relations.  
-* Generalized Hooke’s law.  
-* Applications to aerospace structural elements.  
+### Module 1: Error Analysis and Fundamentals
+* Approximation methods overview
+* Round-off errors analysis
+* Truncation error calculations
+* Error propagation studies
+* Numerical stability concepts
 
-### Module 2: Shear Flow in Thin-Walled Structures
-* Shear stresses in thin-walled open sections.  
-* Shear flow in multicell structures.  
-* Shear center determination for common sections.  
-* Applications to wing and fuselage structural design.  
-* Semi-monocoque construction.  
+### Module 2: Equation Solving and Optimization
+* Roots of equations methods
+* Algebraic equations solutions
+* Optimization techniques
+* Linear and nonlinear optimization
+* Constrained optimization methods
 
-### Module 3: Torsion of Thin-Walled Beams
-* Torsion of closed thin-walled tubes.  
-* Torsion of open sections and warping effects.  
-* Bredt–Batho theory for shear flow in closed sections.  
-* Multi-cell torsion analysis.  
-* Applications in aircraft structural components.  
+### Module 3: Curve Fitting and Approximation
+* Curve fitting principles
+* Regression analysis techniques
+* Interpolation methods
+* Least squares approximation
+* Data smoothing algorithms
 
-### Module 4: Energy Methods and Deflection Analysis
-* Strain energy and complementary energy.  
-* Castigliano’s theorems and applications.  
-* Unit load method.  
-* Deflection of beams and frames.  
-* Energy approach in structural analysis.  
+### Module 4: Numerical Calculus
+* Numerical differentiation methods
+* Numerical integration techniques
+* Richardson extrapolation
+* Romberg integration
+* Adaptive quadrature methods
 
-### Module 5: Buckling and Stability
-* Euler buckling of columns.  
-* Inelastic buckling (introduction).  
-* Local buckling of thin-walled members.  
-* Stability of structural components under compression and shear.  
-* Aerospace applications in wing spars, ribs, and fuselage frames.  
+### Module 5: Differential Equations
+* Ordinary differential equation solutions
+* Initial value problems
+* Boundary value problems
+* Stiff equations handling
+* Partial differential equations introduction
 
 ---
 
 ## References
 
 ### Text Books
-* Megson, T. H. G. – *Aircraft Structures for Engineering Students*, 6th ed., Butterworth-Heinemann (2017).  
-* Timoshenko, S. P. and Gere, J. M. – *Theory of Elastic Stability*, McGraw-Hill (1961).  
+* Chapra, S.C., Canale, R.P. - *Numerical Methods for Engineers*, McGraw-Hill
 
 ### References
-* Bruhn, E. F. – *Analysis and Design of Flight Vehicle Structures*, Tri-State Offset (1973).  
-* Niu, M. C. Y. – *Airframe Structural Design*, Conmilit Press (1999).  
-* Peery, D. J. and Azar, J. J. – *Aircraft Structures*, McGraw-Hill (1982).  
-* Ugural, A. C. – *Stresses in Plates and Shells*, McGraw-Hill (2004).  
+* Cheney, W., Kincaid, D. - *Numerical Mathematics and Computing*, Thompson Brooks/Cole
+* Issacson, E., Keller, H.B. - *Analysis of Numerical Methods*, Dover Publications
+* Hamming, R.W. - *Numerical Methods for Scientist and Engineers*, Dover Publications
+* Acton, F.S. - *Numerical Methods that Work*, Mathematical Association of America
+* Conte, S.D., Boor, C de - *Elementary Numerical Analysis*, McGraw-Hill
+* Atkinson, K.E. - *An Introduction to Numerical Analysis*, Wiley Publications
+* William H. Press, Saul A. Teukolsky, William T. Vetterling, Brian P. Flannery - *Numerical Recipes 3rd Edition: The Art of Scientific Computing*, Cambridge University Press
+* Hairer, E., Wanner, G., Norsett, S.P. - *Solving Ordinary Differential Equations I*, Springer
+* Hairer, E., Wanner, G - *Solving Ordinary Differential Equations II*, Springer

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/04.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/04.md
@@ -4,67 +4,69 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ae303c"
-course_title: "flight-mechanics-i"
+course_code: "ae313h"
+course_title: "industrial-engineering-and-management"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ae303c: flight-mechanics-i
-  - (AE303C: Flight Mechanics I)
+# ae313h: industrial-engineering-and-management
+  - (AE313H: Industrial Engineering and Management)
 
 ## Course Objectives
-* To introduce the fundamentals of aircraft performance and static stability.  
-* To analyze the forces and moments acting on an aircraft in steady and accelerated flight.  
-* To study the performance characteristics related to take-off, landing, climb, and cruise.  
-* To understand longitudinal and lateral static stability criteria.  
+* To understand management functions and corporate objectives
+* To study product design and value engineering principles
+* To learn production planning and control methods
+* To analyze work study and measurement techniques
+* To examine inventory management and quality control systems
 
 ## Course Content
 
-### Module 1: Introduction to Flight Mechanics
-* Reference frames and coordinate systems.  
-* Types of aircraft motions and forces.  
-* Lift, drag, thrust, and weight components.  
-* Aircraft equations of motion (qualitative).  
-* Performance and stability as major analysis domains.  
+### Module 1: Management Fundamentals
+* Introduction to management concepts
+* Functions of a manager: planning, organizing, leading, controlling
+* Functional areas of management
+* Corporate objectives setting
+* Organizational structure and design
 
-### Module 2: Steady Level and Accelerated Flight
-* Conditions for steady level flight.  
-* Thrust required and power required curves.  
-* Range and endurance of propeller-driven and jet aircraft.  
-* Climb and glide performance.  
-* Turning performance — load factor, turn radius, and rate of turn.  
+### Module 2: Product Design and Forecasting
+* Product design principles
+* Value engineering techniques
+* Productivity measurement and improvement
+* Demand forecasting methods
+* Market analysis and product planning
 
-### Module 3: Take-Off and Landing Performance
-* Take-off run and ground roll analysis.  
-* Balanced field length.  
-* Landing distance and approach control.  
-* Influence of wind, flaps, and aircraft mass.  
-* Performance constraints for aircraft design.  
+### Module 3: Production Planning and Work Study
+* Introduction to production planning and control
+* Work study methodologies
+* Motion study techniques
+* Work measurement techniques
+* Time and motion analysis
 
-### Module 4: Static Longitudinal Stability and Control
-* Static stability concepts — restoring moments and equilibrium.  
-* Contribution of wing, tail, and fuselage to stability.  
-* Neutral point and static margin.  
-* Elevator control effectiveness.  
-* Trim conditions for steady flight.  
+### Module 4: Facilities and Inventory Management
+* Facilities location strategies
+* Facilities layout design
+* Inventory management systems
+* Supply chain management
+* Logistics and distribution
 
-### Module 5: Lateral and Directional Static Stability
-* Sideslip and lateral-directional derivatives.  
-* Dihedral effect and roll stability.  
-* Weathercock stability and fin design.  
-* Rudder control and directional trim.  
-* Coupling between roll–yaw motions.  
+### Module 5: Quality and Project Management
+* Total quality management principles
+* Introduction to production management
+* CPM and PERT techniques
+* Case studies in industrial engineering
+* Quality assurance systems
 
 ---
 
 ## References
 
 ### Text Books
-* Anderson, J. D. – *Aircraft Performance and Design*, McGraw-Hill (1999).  
-* Etkin, B. and Reid, L. D. – *Dynamics of Flight: Stability and Control*, 3rd ed., Wiley (1996).  
+* H. Koontz, H. Weihrich, M.V. Cannice - *Essentials of Management*, McGraw Hill, 11th Edition (2020)
 
 ### References
-* McCormick, B. W. – *Aerodynamics, Aeronautics, and Flight Mechanics*, 2nd ed., Wiley (1995).  
-* Nelson, R. C. – *Flight Stability and Automatic Control*, 2nd ed., McGraw-Hill (1998).  
-* Roskam, J. – *Airplane Flight Dynamics and Automatic Flight Controls*, DARcorporation (2001).  
+* R. B. Chase, F. R. Jacobs, N. J. Aquilano, N. K. Agarwal - *Operations Management for competitive advantage*, McGraw Hill Education, 11th Edition (2005)
+* ILO - *Introduction to Work study*, Oxford and IBH Publishing Co. (2010)
+* R. M. Barnes - *Motion and Time Study – Design and Measurement of Work*, John Wiley & Sons, New York (1990)
+* E. S. Buffa and R.K. Sarin - *Modern Production/Operations Management*, Wiley, 8th Edition (2010)
+* K.N. Krishnaswamy and M. Mathirajan - *Cases in Operations Management*, PHI learning (2010)

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/04.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/04.md
@@ -1,0 +1,70 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae303c"
+course_title: "flight-mechanics-i"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae303c: flight-mechanics-i
+  - (AE303C: Flight Mechanics I)
+
+## Course Objectives
+* To introduce the fundamentals of aircraft performance and static stability.  
+* To analyze the forces and moments acting on an aircraft in steady and accelerated flight.  
+* To study the performance characteristics related to take-off, landing, climb, and cruise.  
+* To understand longitudinal and lateral static stability criteria.  
+
+## Course Content
+
+### Module 1: Introduction to Flight Mechanics
+* Reference frames and coordinate systems.  
+* Types of aircraft motions and forces.  
+* Lift, drag, thrust, and weight components.  
+* Aircraft equations of motion (qualitative).  
+* Performance and stability as major analysis domains.  
+
+### Module 2: Steady Level and Accelerated Flight
+* Conditions for steady level flight.  
+* Thrust required and power required curves.  
+* Range and endurance of propeller-driven and jet aircraft.  
+* Climb and glide performance.  
+* Turning performance — load factor, turn radius, and rate of turn.  
+
+### Module 3: Take-Off and Landing Performance
+* Take-off run and ground roll analysis.  
+* Balanced field length.  
+* Landing distance and approach control.  
+* Influence of wind, flaps, and aircraft mass.  
+* Performance constraints for aircraft design.  
+
+### Module 4: Static Longitudinal Stability and Control
+* Static stability concepts — restoring moments and equilibrium.  
+* Contribution of wing, tail, and fuselage to stability.  
+* Neutral point and static margin.  
+* Elevator control effectiveness.  
+* Trim conditions for steady flight.  
+
+### Module 5: Lateral and Directional Static Stability
+* Sideslip and lateral-directional derivatives.  
+* Dihedral effect and roll stability.  
+* Weathercock stability and fin design.  
+* Rudder control and directional trim.  
+* Coupling between roll–yaw motions.  
+
+---
+
+## References
+
+### Text Books
+* Anderson, J. D. – *Aircraft Performance and Design*, McGraw-Hill (1999).  
+* Etkin, B. and Reid, L. D. – *Dynamics of Flight: Stability and Control*, 3rd ed., Wiley (1996).  
+
+### References
+* McCormick, B. W. – *Aerodynamics, Aeronautics, and Flight Mechanics*, 2nd ed., Wiley (1995).  
+* Nelson, R. C. – *Flight Stability and Automatic Control*, 2nd ed., McGraw-Hill (1998).  
+* Roskam, J. – *Airplane Flight Dynamics and Automatic Flight Controls*, DARcorporation (2001).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/05.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/05.md
@@ -1,0 +1,62 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae371h"
+course_title: "numerical-methods-and-optimization-laboratory"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae371h: numerical-methods-and-optimization-laboratory
+  - (AE371H: Numerical Methods and Optimization Laboratory)
+
+## Course Objectives
+* To provide hands-on experience in implementing numerical algorithms.  
+* To develop practical skills in solving engineering problems using numerical techniques.  
+* To analyse optimization problems using computational tools.  
+* To relate numerical and optimization methods to real aerospace applications.  
+
+## Course Content
+
+### Module 1: Programming Foundations for Numerical Methods
+* Introduction to scientific computing tools (MATLAB/Python).  
+* Implementation of algorithms for root-finding.  
+* Error estimation and convergence analysis.  
+* Visualization of numerical results.  
+
+### Module 2: Solutions of Equations and Linear Systems
+* Bisection, Newton–Raphson, and Secant methods.  
+* Gauss elimination and LU decomposition.  
+* Iterative methods – Jacobi and Gauss–Seidel.  
+* Applications to structural and aerodynamic problems.  
+
+### Module 3: Interpolation, Curve Fitting, and Numerical Integration
+* Newton and Lagrange interpolation.  
+* Least-squares curve fitting.  
+* Numerical differentiation and integration (Trapezoidal & Simpson’s).  
+* Applications to aerodynamic data processing.  
+
+### Module 4: Numerical Solution of Differential Equations
+* Euler and modified Euler methods.  
+* Runge–Kutta methods.  
+* Solution of systems of ODEs.  
+* Applications to flight dynamics and thermal systems.  
+
+### Module 5: Optimization Techniques
+* Single-variable optimization – golden-section and Fibonacci search.  
+* Multivariable unconstrained optimization.  
+* Constrained optimization using Lagrange multipliers.  
+* Linear programming using simplex (software-based).  
+* Applications in design optimization and aerospace engineering.  
+
+---
+
+## References
+
+* Chapra, S. C. and Canale, R. P. – *Numerical Methods for Engineers*, 8th ed., McGraw-Hill (2020).  
+* Rao, S. S. – *Engineering Optimization: Theory and Practice*, 4th ed., Wiley (2009).  
+* Burden, R. L. and Faires, J. D. – *Numerical Analysis*, 10th ed., Cengage (2015).  
+* Taha, H. A. – *Operations Research: An Introduction*, 10th ed., Pearson (2017).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/05.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/05.md
@@ -4,59 +4,68 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ae371h"
-course_title: "numerical-methods-and-optimization-laboratory"
+course_code: "e01c"
+course_title: "program-elective-slot-1"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ae371h: numerical-methods-and-optimization-laboratory
-  - (AE371H: Numerical Methods and Optimization Laboratory)
+# e01c: program-elective-slot-1
+  - (E01 (C): Program Elective (Slot 1))
 
 ## Course Objectives
-* To provide hands-on experience in implementing numerical algorithms.  
-* To develop practical skills in solving engineering problems using numerical techniques.  
-* To analyse optimization problems using computational tools.  
-* To relate numerical and optimization methods to real aerospace applications.  
+* To provide specialized knowledge in chosen elective area
+* To develop advanced understanding of specific aerospace topics
+* To enhance analytical and problem-solving skills in elective domain
+* To prepare students for advanced studies or industry applications
+* To bridge theoretical knowledge with practical applications
 
 ## Course Content
 
-### Module 1: Programming Foundations for Numerical Methods
-* Introduction to scientific computing tools (MATLAB/Python).  
-* Implementation of algorithms for root-finding.  
-* Error estimation and convergence analysis.  
-* Visualization of numerical results.  
+### Module 1: Elective Foundation
+* Introduction to elective subject area
+* Fundamental concepts and principles
+* Historical development and current trends
+* Applications in aerospace engineering
+* Scope and importance of the elective
 
-### Module 2: Solutions of Equations and Linear Systems
-* Bisection, Newton–Raphson, and Secant methods.  
-* Gauss elimination and LU decomposition.  
-* Iterative methods – Jacobi and Gauss–Seidel.  
-* Applications to structural and aerodynamic problems.  
+### Module 2: Core Theories and Methods
+* Theoretical frameworks in elective domain
+* Analytical methods and approaches
+* Mathematical modeling techniques
+* Computational methods if applicable
+* Experimental methods and validation
 
-### Module 3: Interpolation, Curve Fitting, and Numerical Integration
-* Newton and Lagrange interpolation.  
-* Least-squares curve fitting.  
-* Numerical differentiation and integration (Trapezoidal & Simpson’s).  
-* Applications to aerodynamic data processing.  
+### Module 3: Advanced Concepts
+* Advanced topics in elective area
+* Specialized techniques and tools
+* Current research directions
+* Industry practices and standards
+* Emerging technologies and innovations
 
-### Module 4: Numerical Solution of Differential Equations
-* Euler and modified Euler methods.  
-* Runge–Kutta methods.  
-* Solution of systems of ODEs.  
-* Applications to flight dynamics and thermal systems.  
+### Module 4: Applications and Case Studies
+* Practical applications in aerospace
+* Case studies from industry
+* Design and analysis examples
+* Problem-solving approaches
+* Integration with core aerospace subjects
 
-### Module 5: Optimization Techniques
-* Single-variable optimization – golden-section and Fibonacci search.  
-* Multivariable unconstrained optimization.  
-* Constrained optimization using Lagrange multipliers.  
-* Linear programming using simplex (software-based).  
-* Applications in design optimization and aerospace engineering.  
+### Module 5: Future Directions and Projects
+* Future trends and developments
+* Research opportunities
+* Mini-project or case analysis
+* Industry relevance and career paths
+* Ethical and societal considerations
 
 ---
 
 ## References
 
-* Chapra, S. C. and Canale, R. P. – *Numerical Methods for Engineers*, 8th ed., McGraw-Hill (2020).  
-* Rao, S. S. – *Engineering Optimization: Theory and Practice*, 4th ed., Wiley (2009).  
-* Burden, R. L. and Faires, J. D. – *Numerical Analysis*, 10th ed., Cengage (2015).  
-* Taha, H. A. – *Operations Research: An Introduction*, 10th ed., Pearson (2017).  
+### Text Books
+* To be specified based on elective selection
+
+### References
+* To be specified based on elective selection
+* Journal papers and conference proceedings
+* Industry standards and specifications
+* Technical reports and manuals

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/06.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/06.md
@@ -1,0 +1,62 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae381h"
+course_title: "flight-mechanics-laboratory"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae381h: flight-mechanics-laboratory
+  - (AE381H: Flight Mechanics Laboratory)
+
+## Course Objectives
+* To experimentally study aircraft performance and stability characteristics.  
+* To provide hands-on experience with flight data, instrumentation, and analysis tools.  
+* To verify theoretical concepts from Flight Mechanics I through experiments and simulations.  
+* To develop skills in aerodynamic data reduction, interpretation, and reporting.  
+
+## Course Content
+
+### Module 1: Introduction to Flight Experiments
+* Familiarization with flight mechanics laboratory setup.  
+* Introduction to flight test instrumentation.  
+* Data acquisition and signal processing.  
+* Calibration of sensors (pressure, velocity, angle).  
+
+### Module 2: Performance Measurements
+* Measurement of lift, drag, and moment coefficients.  
+* Determination of thrust required and power required curves.  
+* Estimation of stall characteristics.  
+* Range and endurance analysis (data-driven).  
+
+### Module 3: Stability Experiments
+* Longitudinal static stability – determination of neutral point and static margin.  
+* Elevator control effectiveness.  
+* Lateral–directional stability – dihedral effect and weathercock stability.  
+* Control derivative estimation (via experiments or simulation).  
+
+### Module 4: Flight Dynamics and Simulation
+* Use of flight simulation software/tools.  
+* Aircraft response to step and impulse control inputs.  
+* Short-period and phugoid mode identification (simulation-based).  
+* Spiral, Dutch roll, and roll subsidence modes.  
+
+### Module 5: Data Processing and Report Preparation
+* Data filtering, error estimation, and uncertainty analysis.  
+* Comparison of experimental, theoretical, and simulation data.  
+* Preparation of structured flight test reports.  
+* Case studies from real aircraft flight tests (intro).  
+
+---
+
+## References
+
+* Etkin, B. and Reid, L. D. – *Dynamics of Flight: Stability and Control*, 3rd ed., Wiley (1996).  
+* McCormick, B. W. – *Aerodynamics, Aeronautics, and Flight Mechanics*, 2nd ed., Wiley (1995).  
+* Nelson, R. C. – *Flight Stability and Automatic Control*, 2nd ed., McGraw-Hill (1998).  
+* Anderson, J. D. – *Aircraft Performance and Design*, McGraw-Hill (1999).  
+* Roskam, J. – *Airplane Flight Dynamics and Automatic Flight Controls*, DARcorporation (2001).  

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/06.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/06.md
@@ -4,59 +4,68 @@ university: "indian-institute-of-space-science-and-technology"
 branch: "aerospace-engineering"
 version: "2024"
 semester: 5
-course_code: "ae381h"
-course_title: "flight-mechanics-laboratory"
+course_code: "e02m"
+course_title: "minor-stream-elective-slot-1"
 language: "english"
 contributor: "@chandrasagardev"
 ---
 
-# ae381h: flight-mechanics-laboratory
-  - (AE381H: Flight Mechanics Laboratory)
+# e02m: minor-stream-elective-slot-1
+  - (E02 (M): Minor Stream Elective (Slot 1))
 
 ## Course Objectives
-* To experimentally study aircraft performance and stability characteristics.  
-* To provide hands-on experience with flight data, instrumentation, and analysis tools.  
-* To verify theoretical concepts from Flight Mechanics I through experiments and simulations.  
-* To develop skills in aerodynamic data reduction, interpretation, and reporting.  
+* To provide interdisciplinary knowledge in minor stream area
+* To develop complementary skills outside core aerospace domain
+* To enhance versatility and broad-based engineering education
+* To understand applications of minor stream in aerospace context
+* To foster innovation through cross-disciplinary approaches
 
 ## Course Content
 
-### Module 1: Introduction to Flight Experiments
-* Familiarization with flight mechanics laboratory setup.  
-* Introduction to flight test instrumentation.  
-* Data acquisition and signal processing.  
-* Calibration of sensors (pressure, velocity, angle).  
+### Module 1: Minor Stream Fundamentals
+* Introduction to minor stream discipline
+* Basic concepts and terminology
+* Relevance to aerospace engineering
+* Interdisciplinary connections
+* Scope and learning objectives
 
-### Module 2: Performance Measurements
-* Measurement of lift, drag, and moment coefficients.  
-* Determination of thrust required and power required curves.  
-* Estimation of stall characteristics.  
-* Range and endurance analysis (data-driven).  
+### Module 2: Core Principles and Methods
+* Fundamental principles of minor stream
+* Analytical and computational methods
+* Experimental techniques if applicable
+* Data analysis and interpretation
+* Standard practices and procedures
 
-### Module 3: Stability Experiments
-* Longitudinal static stability – determination of neutral point and static margin.  
-* Elevator control effectiveness.  
-* Lateral–directional stability – dihedral effect and weathercock stability.  
-* Control derivative estimation (via experiments or simulation).  
+### Module 3: Advanced Topics and Applications
+* Advanced concepts in minor stream
+* Specialized applications in engineering
+* Integration with aerospace systems
+* Case studies and examples
+* Current research developments
 
-### Module 4: Flight Dynamics and Simulation
-* Use of flight simulation software/tools.  
-* Aircraft response to step and impulse control inputs.  
-* Short-period and phugoid mode identification (simulation-based).  
-* Spiral, Dutch roll, and roll subsidence modes.  
+### Module 4: Aerospace Integration
+* Applications in aerospace systems
+* Cross-disciplinary problem solving
+* System integration approaches
+* Design considerations
+* Performance evaluation methods
 
-### Module 5: Data Processing and Report Preparation
-* Data filtering, error estimation, and uncertainty analysis.  
-* Comparison of experimental, theoretical, and simulation data.  
-* Preparation of structured flight test reports.  
-* Case studies from real aircraft flight tests (intro).  
+### Module 5: Project and Future Scope
+* Mini-project application
+* Future trends and opportunities
+* Career pathways
+* Research directions
+* Industry requirements and standards
 
 ---
 
 ## References
 
-* Etkin, B. and Reid, L. D. – *Dynamics of Flight: Stability and Control*, 3rd ed., Wiley (1996).  
-* McCormick, B. W. – *Aerodynamics, Aeronautics, and Flight Mechanics*, 2nd ed., Wiley (1995).  
-* Nelson, R. C. – *Flight Stability and Automatic Control*, 2nd ed., McGraw-Hill (1998).  
-* Anderson, J. D. – *Aircraft Performance and Design*, McGraw-Hill (1999).  
-* Roskam, J. – *Airplane Flight Dynamics and Automatic Flight Controls*, DARcorporation (2001).  
+### Text Books
+* To be specified based on minor stream elective selection
+
+### References
+* To be specified based on minor stream elective selection
+* Interdisciplinary research papers
+* Application case studies
+* Industry guidelines and standards

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/07.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/07.md
@@ -1,0 +1,71 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "ae331c"
+course_title: "flight-mechanics-and-propulsion-lab"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# ae331c: flight-mechanics-and-propulsion-lab
+  - (AE331C: Flight Mechanics and Propulsion Lab)
+
+## Course Objectives
+* To simulate accelerated maneuvers and analyze flight dynamics
+* To estimate aerodynamic parameters from experimental data
+* To study gas turbine cycles and propulsion system performance
+* To conduct experiments on various propulsion components
+* To analyze ramjet engine performance characteristics
+
+## Course Content
+
+### Module 1: Flight Mechanics Experiments
+* Simulation of accelerated maneuvers using whirling arm
+* Flight dynamics analysis
+* Maneuver simulation techniques
+* Data acquisition and processing
+* Experimental validation of theoretical models
+
+### Module 2: Aerodynamic Parameter Estimation
+* Estimation of neutral point from simulated flight data
+* Drag polar estimation of glider from simulated flight data
+* Aerodynamic coefficient determination
+* Flight test data analysis
+* Parameter identification methods
+
+### Module 3: Inertia Measurements and Propulsion Fundamentals
+* Estimation of moment of inertia of UAV using Bi-filar pendulum
+* Inertia measurement techniques
+* Gas turbine cycle study and analysis
+* Thermodynamic cycle analysis
+* Performance parameter calculations
+
+### Module 4: Turbojet and Turbomachinery Experiments
+* Performance analysis of turbojet engine
+* Experiments on axial flow fan
+* Experimental impulse turbine module
+* Turbomachinery performance evaluation
+* Efficiency calculations and analysis
+
+### Module 5: Advanced Propulsion Systems
+* Experimental reaction turbine module
+* Experiments on ramjet engine
+* Reaction turbine performance
+* Ramjet operation principles
+* Advanced propulsion system analysis
+
+---
+
+## References
+
+### Text Books
+* Lab Manuals / Study Materials
+
+### References
+* Laboratory procedure guides
+* Experimental methods handbooks
+* Data analysis techniques
+* Safety protocols and standards

--- a/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/08.md
+++ b/universities/indian-institute-of-space-science-and-technology/aerospace-engineering/2024/s05/08.md
@@ -1,0 +1,72 @@
+---
+country: "india"
+university: "indian-institute-of-space-science-and-technology"
+branch: "aerospace-engineering"
+version: "2024"
+semester: 5
+course_code: "av332c"
+course_title: "instrumentation-and-control-lab"
+language: "english"
+contributor: "@chandrasagardev"
+---
+
+# av332c: instrumentation-and-control-lab
+  - (AV332C: Instrumentation and Control Lab)
+
+## Course Objectives
+* To familiarize with MATLAB and SIMULINK environments
+* To model, simulate and analyze linear systems
+* To design compensators for various control applications
+* To study sensors and instrumentation systems
+* To implement open loop and closed loop control systems
+
+## Course Content
+
+### Module 1: Software Familiarization and Basic Modeling
+* Familiarization with MATLAB environment
+* SIMULINK basics and interface
+* Linear system modeling techniques
+* Basic simulation methods
+* Model verification and validation
+
+### Module 2: System Simulation and Analysis
+* Linear system simulation methods
+* System analysis techniques
+* Time domain analysis
+* Frequency domain analysis
+* Performance evaluation metrics
+
+### Module 3: Compensator Design and Implementation
+* Compensator design principles
+* Design for various applications
+* Controller implementation
+* Performance optimization
+* Stability analysis methods
+
+### Module 4: Control System Implementation
+* Open loop control examples
+* Close loop control implementations
+* Feedback system design
+* Real-time implementation
+* System tuning and adjustment
+
+### Module 5: Instrumentation Systems
+* Study of sensors and transducers
+* Instrumentation systems overview
+* Signal conditioning techniques
+* Data acquisition systems
+* Measurement uncertainty analysis
+
+---
+
+## References
+
+### Text Books
+* Lab Manual
+
+### References
+* MATLAB and SIMULINK documentation
+* Control systems textbooks
+* Instrumentation handbooks
+* Experimental procedure guides
+* Data sheets and technical manuals


### PR DESCRIPTION
### Summary
Added all Semester 5 courses for the Indian Institute of Space Science and Technology (Aerospace Engineering 2024 scheme).

### Details
- Added 8 syllabus markdown files (`01.md` – `08.md`) under `s05/`

**Contributor:** @chandrasagardev
