### PR TITLE
Add the PYQ contribution format: previous year question papers

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -10,12 +10,36 @@ Together, we can make a fully open, searchable, and markdown-based syllabus inde
 
 - ✅ **New Syllabus Files**  
   - Add missing course markdowns (`.md`) for different branches, semesters, or years.
+- 📄 **Previous Year Question Papers (PYQs)**  
+  - Add publicly circulated exam papers next to their subject — see the section below.
 - 🛠️ **Fix Errors**  
   - Typos, outdated content, or formatting issues.
 - 📘 **Add References**  
   - Useful books, links, or official sources for specific courses.
 - 💡 **Improve Structure**  
   - Suggestions for folder naming, file structure, or tagging.
+
+---
+
+## 📄 Previous Year Question Papers (PYQs)
+
+Every PYQ you contribute becomes practice material inside [Beyond Syllabus](https://github.com/The-Purple-Movement/Beyond-Syllabus) for every student of that course.
+
+**Location and naming (both matter):**
+
+```
+universities/<university>/<branch>/<scheme-year>/<sNN>/pyq/<subjectid>-<examyear>[-<session>].md
+```
+
+`<subjectid>` is the basename of the subject's syllabus file in the same semester folder: questions for `01.md` go in `pyq/01-2023-may.md`.
+
+**Rules:**
+
+1. Start from [`pyq-template.md`](./pyq-template.md) — frontmatter requires `course_code`, `exam_year`, and `contributor`
+2. One file per paper: May and December sessions are separate files
+3. Transcribe faithfully: keep marks, parts, and question numbers
+4. Only papers **publicly circulated by the university** — no leaked or purchased material, ever
+5. The validator checks PYQ files automatically on your PR
 
 ---
 

--- a/pyq-template.md
+++ b/pyq-template.md
@@ -1,0 +1,47 @@
+---
+country: "india"
+university: "ktu"
+branch: "computer-science"
+version: "2019"
+semester: 8
+course_code: "cst402"
+exam_year: "2023"
+session: "may"
+language: "english"
+contributor: "@your-github-username"
+---
+
+<!--
+PREVIOUS YEAR QUESTION PAPER TEMPLATE
+
+File location and name (both matter):
+  universities/<university>/<branch>/<scheme-year>/<sNN>/pyq/<subjectid>-<examyear>[-<session>].md
+
+  <subjectid> = the basename of the subject's syllabus file in the same
+  semester folder (e.g. questions for 01.md go in pyq/01-2023-may.md).
+
+Rules:
+- Transcribe the paper faithfully: marks, parts, and question numbers included.
+- Only contribute papers that are publicly circulated by the university.
+- One file per paper (year + session). December and May papers are separate files.
+- Delete this comment block before submitting.
+-->
+
+# CST402 Distributed Computing — May 2023
+
+**Time:** 3 hours · **Max marks:** 100
+
+## Part A (answer all questions; 3 marks each)
+
+1. Define the happened-before relation with an example.
+2. ...
+
+## Part B (answer one full question from each module; 14 marks each)
+
+### Module 1
+
+11. a) Explain the differences between synchronous and asynchronous message passing. (7)
+    b) ... (7)
+
+12. a) ... (7)
+    b) ... (7)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -29,6 +29,14 @@ PATH_RE = re.compile(
     r"^universities/([a-z0-9-]+)/([a-z0-9-]+)/(\d{4})/(s\d{2})/([a-z0-9_-]+)\.md$"
 )
 
+# Previous-year question papers:
+# universities/<university>/<branch>/<year>/<semester>/pyq/<subjectid>-<examyear>[-<session>].md
+PYQ_PATH_RE = re.compile(
+    r"^universities/([a-z0-9-]+)/([a-z0-9-]+)/(\d{4})/(s\d{2})/pyq/([a-z0-9_]+)-(\d{4})(?:-([a-z]+))?\.md$"
+)
+
+PYQ_REQUIRED_FIELDS = ["course_code", "exam_year", "contributor"]
+
 # Accepted short codes: frontmatter may use the alias while the folder uses
 # the canonical slug. Extend this map when a new university has an
 # established short name.
@@ -64,9 +72,53 @@ def parse_frontmatter(text):
     return data, None
 
 
+def validate_pyq(path, rel, match):
+    """Validate a previous-year-question paper file."""
+    errors, warnings = [], []
+    exam_year = match.group(6)
+    try:
+        text = open(path, encoding="utf-8").read()
+    except Exception as exc:
+        return [f"unreadable: {exc}"], warnings
+
+    fm, err = parse_frontmatter(text)
+    if err:
+        errors.append(err)
+        return errors, warnings
+
+    for field in PYQ_REQUIRED_FIELDS:
+        if field not in fm or not fm[field]:
+            errors.append(f"frontmatter missing required field: {field}")
+
+    if fm.get("exam_year") and fm["exam_year"] != exam_year:
+        errors.append(
+            f"frontmatter exam_year '{fm['exam_year']}' does not match filename year '{exam_year}'"
+        )
+
+    if fm.get("contributor") and not fm["contributor"].startswith("@"):
+        warnings.append("contributor should be a GitHub handle starting with @")
+
+    body = text.lstrip()
+    body = body[body.find("\n---") + 4:] if body.startswith("---") else body
+    if len(body.strip()) < 80:
+        warnings.append("paper body looks near-empty; add the actual questions")
+
+    return errors, warnings
+
+
 def validate_file(path):
     errors, warnings = [], []
     rel = os.path.relpath(path).replace(os.sep, "/")
+
+    pyq = PYQ_PATH_RE.match(rel)
+    if pyq:
+        return validate_pyq(path, rel, pyq)
+
+    if "/pyq/" in rel:
+        errors.append(
+            "pyq path must match universities/<u>/<b>/<year>/<sNN>/pyq/<subjectid>-<examyear>[-<session>].md"
+        )
+        return errors, warnings
 
     m = PATH_RE.match(rel)
     if not m:


### PR DESCRIPTION
The data-layer half of Beyond-Syllabus issue #16. PYQs live next to their subject:

```
universities/<u>/<b>/<scheme-year>/<sNN>/pyq/<subjectid>-<examyear>[-<session>].md
```

- **[pyq-template.md](https://github.com/deepusnath/WikiSyllabus-Purple/blob/pyq-format/pyq-template.md)**: required frontmatter (course_code, exam_year, contributor) + transcription rules
- **CONTRIBUTION.md**: the PYQ section, with the bright line: only papers publicly circulated by the university, ever
- **validate.py**: PYQ path + frontmatter checks (filename exam year must match frontmatter), tested on good and bad fixtures; runs automatically in the PR workflow

Companion PR in Beyond-Syllabus parses this format into per-subject practice material, so every paper contributed here lights up for every student of that course.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)