### PR TITLE
Normalize frontmatter from merged community PRs

### DIFF
--- a/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/01.md
+++ b/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/01.md
@@ -1,7 +1,7 @@
 ---
 country: "india"
 university: "mahatma-gandhi-university"
-branch: "master-of-computer-applications"
+branch: "master-of-computer-application"
 version: "2024"
 semester: "1"
 course_code: "MCA-CT-101"

--- a/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/02.md
+++ b/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/02.md
@@ -1,7 +1,7 @@
 ---
 country: "india"
 university: "mahatma-gandhi-university"
-branch: "master-of-computer-applications"
+branch: "master-of-computer-application"
 version: "2024"
 semester: "1"
 course_code: "MCA-CT-102"

--- a/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/03.md
+++ b/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/03.md
@@ -1,7 +1,7 @@
 ---
 country: "india"
 university: "mahatma-gandhi-university"
-branch: "master-of-computer-applications"
+branch: "master-of-computer-application"
 version: "2024"
 semester: "1"
 course_code: "MCA-CT-103"

--- a/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/04.md
+++ b/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/04.md
@@ -1,7 +1,7 @@
 ---
 country: "india"
 university: "mahatma-gandhi-university"
-branch: "master-of-computer-applications"
+branch: "master-of-computer-application"
 version: "2024"
 semester: "1"
 course_code: "MCA-CT-104"

--- a/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/05.md
+++ b/universities/mahatma-gandhi-university/master-of-computer-application/2024/s01/05.md
@@ -1,7 +1,7 @@
 ---
 country: "india"
 university: "mahatma-gandhi-university"
-branch: "master-of-computer-applications"
+branch: "master-of-computer-application"
 version: "2024"
 semester: "1"
 course_code: "MCA-CT-105"

--- a/universities/university-of-toronto/computer-science/2022/s01/01.md
+++ b/universities/university-of-toronto/computer-science/2022/s01/01.md
@@ -4,7 +4,7 @@ university: "university-of-toronto"
 branch: "computer-science"
 version: "2022"
 semester: 1
-course_code: "csc108hi"
+course_code: "csc108h1"
 course_title: "introduction-to-computer-programming"
 language: "english"
 contributor: "@geogeorge46"


### PR DESCRIPTION
The follow-up promised in the #151 and #175 review comments: fixes the 5 branch-name warnings (MG University MCA) and the csc108hi -> csc108h1 course-code typo (U of T). validate.py is 0/0 on all six files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)