### PR TITLE
Repair shadowed frontmatter in KTU CSD 2024 and restore attribution

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Validator regression tests
+        run: python3 scripts/tests/test_shadowed_frontmatter.py
+
       - name: Validate every syllabus file
         run: python3 scripts/validate.py

--- a/scripts/tests/test_shadowed_frontmatter.py
+++ b/scripts/tests/test_shadowed_frontmatter.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regression tests for the shadowed-frontmatter rule.
+
+Scope is deliberately narrow: this covers the one rule added alongside the
+KTU CSD 2024 repair. It is not a general test suite for the validator.
+
+The rule exists because a repair once prepended a generated frontmatter block
+onto files whose own block was merely missing its opening delimiter. The
+danger in detecting that is `---`, which is also a Markdown horizontal rule
+and appears in the body of more than a thousand files in this repository. Most
+cases below are there to prove the rule does not fire on those.
+
+Run:  python3 scripts/tests/test_shadowed_frontmatter.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from validate import shadowed_frontmatter  # noqa: E402
+
+GOOD_BLOCK = """country: "india"
+university: "ktu"
+branch: "computer-science-and-design"
+version: "2024"
+semester: 3
+course_code: "gamat301"
+course_title: "mathematics-for-computer-and-information-science-3"
+language: "english"
+contributor: "@sandra07alex\""""
+
+CASES = []
+
+
+def case(name, expected):
+    def wrap(fn):
+        CASES.append((name, expected, fn()))
+        return fn
+    return wrap
+
+
+@case("the real defect: a generated block shadowing the original", True)
+def _():
+    synthetic = GOOD_BLOCK.replace('"gamat301"', '"unknown"').replace(
+        "@sandra07alex", "@backfill-needed")
+    return f"---\n{synthetic}\n---\n\n{GOOD_BLOCK}\n---\n\n# GAMAT301: Maths\n\nBody.\n"
+
+
+@case("a legitimate file with one frontmatter block", False)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n\n# GAMAT301: Maths\n\nBody text here.\n"
+
+
+@case("a horizontal rule in the body", False)
+def _():
+    return (f"---\n{GOOD_BLOCK}\n---\n\n# Course\n\n## Objectives\n\n"
+            "Learn things.\n\n---\n\n## Modules\n\nModule 1.\n")
+
+
+@case("a fenced example containing ---", False)
+def _():
+    return (f"---\n{GOOD_BLOCK}\n---\n\n# Course\n\nFrontmatter looks like this:\n\n"
+            f"```yaml\n---\n{GOOD_BLOCK}\n---\n```\n\nEnd.\n")
+
+
+@case("body prose starting with 'country:' then a later horizontal rule", False)
+def _():
+    return (f"---\n{GOOD_BLOCK}\n---\n\ncountry: this module covers country-level "
+            "data modelling\n\nand more prose\n\n---\n\n## Next\n")
+
+
+@case("an incomplete YAML-like block (missing required fields)", False)
+def _():
+    return (f"---\n{GOOD_BLOCK}\n---\n\ncountry: \"india\"\nuniversity: \"ktu\"\n"
+            "---\n\n# Course\n")
+
+
+@case("a second block with a duplicated field", False)
+def _():
+    dup = GOOD_BLOCK + '\nlanguage: "english"'
+    return f"---\n{GOOD_BLOCK}\n---\n\n{dup}\n---\n\n# Course\n"
+
+
+@case("a second block containing a blank line", False)
+def _():
+    holed = GOOD_BLOCK.replace('semester: 3', 'semester: 3\n')
+    return f"---\n{GOOD_BLOCK}\n---\n\n{holed}\n---\n\n# Course\n"
+
+
+@case("a file with no frontmatter at all", False)
+def _():
+    return "# Just a heading\n\nSome prose.\n\n---\n\nMore prose.\n"
+
+
+@case("blank lines between the two blocks are still the defect", True)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n\n\n\n{GOOD_BLOCK}\n---\n\n# Course\n"
+
+
+def main():
+    failed = 0
+    for name, expected, text in CASES:
+        got = shadowed_frontmatter(text)
+        ok = got == expected
+        if not ok:
+            failed += 1
+        print(f"  {'PASS' if ok else 'FAIL'}  expected={expected!s:5} got={got!s:5}  {name}")
+    print(f"\n{len(CASES) - failed}/{len(CASES)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_shadowed_frontmatter.py
+++ b/scripts/tests/test_shadowed_frontmatter.py
@@ -96,6 +96,32 @@ def _():
     return f"---\n{GOOD_BLOCK}\n---\n\n\n\n{GOOD_BLOCK}\n---\n\n# Course\n"
 
 
+@case("a metadata-shaped body closed by ---- is not a delimiter", False)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n\n{GOOD_BLOCK}\n----\n\n# Course\n"
+
+
+@case("a metadata-shaped body closed by ---text is not a delimiter", False)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n\n{GOOD_BLOCK}\n---text\n\n# Course\n"
+
+
+@case("a metadata-shaped body closed by '--- # comment' is not a delimiter", False)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n\n{GOOD_BLOCK}\n--- # closing\n\n# Course\n"
+
+
+@case("whitespace-only lines between the blocks are still blank", True)
+def _():
+    return f"---\n{GOOD_BLOCK}\n---\n   \n\t\n  \t  \n{GOOD_BLOCK}\n---\n\n# Course\n"
+
+
+@case("a fenced yaml example immediately after the frontmatter", False)
+def _():
+    return (f"---\n{GOOD_BLOCK}\n---\n\n```yaml\n{GOOD_BLOCK}\n---\n```\n\n"
+            "# Course\n\nBody.\n")
+
+
 def main():
     failed = 0
     for name, expected, text in CASES:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -139,6 +139,20 @@ def validate_overview(path):
     return errors, warnings
 
 
+def _is_blank(line):
+    """Blank means no content, so spaces and tabs count as blank."""
+    return not line.strip()
+
+
+def _is_delimiter(line):
+    """A frontmatter delimiter is a line whose whole content is exactly ---.
+
+    Not ----, not --- followed by text, not --- with a trailing comment. A
+    Markdown horizontal rule of four or more dashes is not a delimiter either.
+    """
+    return line.strip() == "---"
+
+
 def shadowed_frontmatter(text):
     """True when a second, complete frontmatter block follows the first.
 
@@ -152,35 +166,36 @@ def shadowed_frontmatter(text):
     if it carries every required field exactly once and nothing else, which
     ordinary prose and rules do not.
     """
-    if not text.lstrip().startswith("---"):
+    lines = text.lstrip().split("\n")
+    if not lines or not _is_delimiter(lines[0]):
         return False
-    stripped = text.lstrip()
-    first_end = stripped.find("\n---", 3)
-    if first_end == -1:
+    first_end = next((i for i in range(1, len(lines)) if _is_delimiter(lines[i])), None)
+    if first_end is None:
         return False
 
-    after = stripped[first_end + 4:]
-    if after[:1] not in ("\n", ""):        # the delimiter must end its own line
-        return False
-    candidate_start = after.lstrip("\n")   # blank lines between blocks are allowed
-    second_end = candidate_start.find("\n---")
-    if second_end == -1:
-        return False
-    block = candidate_start[:second_end]
+    i = first_end + 1
+    while i < len(lines) and _is_blank(lines[i]):
+        i += 1                             # blank lines between blocks are allowed
+    start = i
 
-    # A fence opening before the candidate means we are inside a code example.
-    if (after[: len(after) - len(candidate_start)] + block).count("```") % 2:
+    # A fence opened above means the candidate sits inside a code example.
+    if "\n".join(lines[:start]).count("```") % 2:
         return False
-    if "```" in block:
-        return False
+
+    block = []
+    while i < len(lines) and not _is_delimiter(lines[i]):
+        block.append(lines[i])
+        i += 1
+    if i >= len(lines) or not block:
+        return False                       # never closed by a standalone ---
 
     seen = []
-    for line in block.split("\n"):
-        if not line.strip():
+    for line in block:
+        if _is_blank(line):
             return False                   # frontmatter blocks have no blank lines
         m = re.match(r"^([a-z_]+):\s*\S", line)
         if not m:
-            return False                   # prose, indentation or a bare word
+            return False                   # prose, a fence, indentation, a bare word
         seen.append(m.group(1))
     return sorted(seen) == sorted(REQUIRED_FIELDS)
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -139,6 +139,52 @@ def validate_overview(path):
     return errors, warnings
 
 
+def shadowed_frontmatter(text):
+    """True when a second, complete frontmatter block follows the first.
+
+    A repair in this repository once prepended a generated block onto files
+    whose own frontmatter was merely missing its opening delimiter. The result
+    parses as valid (the parser stops at the first block) while the real
+    metadata sits below it, unread, and the contributor loses attribution.
+
+    The test is deliberately strict, because `---` is also a Markdown
+    horizontal rule and over a thousand files use one. A block qualifies only
+    if it carries every required field exactly once and nothing else, which
+    ordinary prose and rules do not.
+    """
+    if not text.lstrip().startswith("---"):
+        return False
+    stripped = text.lstrip()
+    first_end = stripped.find("\n---", 3)
+    if first_end == -1:
+        return False
+
+    after = stripped[first_end + 4:]
+    if after[:1] not in ("\n", ""):        # the delimiter must end its own line
+        return False
+    candidate_start = after.lstrip("\n")   # blank lines between blocks are allowed
+    second_end = candidate_start.find("\n---")
+    if second_end == -1:
+        return False
+    block = candidate_start[:second_end]
+
+    # A fence opening before the candidate means we are inside a code example.
+    if (after[: len(after) - len(candidate_start)] + block).count("```") % 2:
+        return False
+    if "```" in block:
+        return False
+
+    seen = []
+    for line in block.split("\n"):
+        if not line.strip():
+            return False                   # frontmatter blocks have no blank lines
+        m = re.match(r"^([a-z_]+):\s*\S", line)
+        if not m:
+            return False                   # prose, indentation or a bare word
+        seen.append(m.group(1))
+    return sorted(seen) == sorted(REQUIRED_FIELDS)
+
+
 def validate_file(path):
     errors, warnings = [], []
     rel = os.path.relpath(path).replace(os.sep, "/")
@@ -179,6 +225,13 @@ def validate_file(path):
     if err:
         errors.append(err)
         return errors, warnings
+
+    if shadowed_frontmatter(text):
+        errors.append(
+            "a second complete frontmatter block follows the first; the block "
+            "below is unread and its contributor loses attribution. Keep one "
+            "block, and check git history before discarding either"
+        )
 
     for field in REQUIRED_FIELDS:
         if field not in fm or not fm[field]:

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/01.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "gamat301-mathematics-for-computer-and-information-science-3"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"
@@ -18,7 +7,7 @@ semester: 3
 course_code: "gamat301"
 course_title: "mathematics-for-computer-and-information-science-3"
 language: "english"
-contributor: "@sandrao7alex"
+contributor: "@sandra07alex"
 ---
 
 # GAMAT301: Mathematics for Computer and Information Science-3

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/02.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/02.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "pccst302-theory-of-computation"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/03.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/03.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "pccst303-data-structures-and-algorithms"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/04.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/04.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "pbcst304-object-oriented-programming"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/05.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/05.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "uchut347-engineering-ethics-and-sustainable-development"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/06.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/06.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "pccsl305-data-structures-lab"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/07.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/07.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "unknown"
-course_title: "pccsl307-digital-systems-lab"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/08.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/08.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 3
-course_code: "oecs301"
-course_title: "oecs301-introduction-to-artificial-intelligence"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/02.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/02.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 4
-course_code: "unknown"
-course_title: "pccst402-database-management-systems"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/03.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/03.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 4
-course_code: "unknown"
-course_title: "pccst403-operating-systems"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/04.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s04/04.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 4
-course_code: "unknown"
-course_title: "pecst412-pattern-recognition"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"
@@ -19,6 +8,7 @@ course_code: "pecst412"
 course_title: "pattern-recognition"
 language: "english"
 contributor: "@sandra07alex"
+---
 
 # PECST412: Pattern Recognition
 

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/02.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/02.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 5
-course_code: "unknown"
-course_title: "pccst502-design-and-analysis-of-algorithms"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/03.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/03.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 5
-course_code: "unknown"
-course_title: "pccnt503-web-programming"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/04.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/04.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 5
-course_code: "unknown"
-course_title: "pbcnt504-virtual-reality"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/05.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s05/05.md
@@ -1,16 +1,5 @@
 ---
 country: "india"
-university: "a-p-j-abdul-kalam-technological-university"
-branch: "computer-science-and-design"
-version: "2024"
-semester: 5
-course_code: "unknown"
-course_title: "pccnl507-web-programming-lab"
-language: "english"
-contributor: "@backfill-needed"
----
-
-country: "india"
 university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"


### PR DESCRIPTION
## What is wrong

Fifteen files in `computer-science-and-design/2024` carry **two** frontmatter blocks. The parser stops at the first, so the second is never read.

```yaml
---
country: "india"
course_code: "unknown"
course_title: "gamat301-mathematics-for-computer-and-information-science-3"
contributor: "@backfill-needed"          # <- what the validator and CONTRIBUTORS.md see
---

country: "india"
course_code: "gamat301"                  # <- correct, and invisible
course_title: "mathematics-for-computer-and-information-science-3"
contributor: "@sandra07alex"             # <- the real contributor, unattributed
---
```

## Why

Commit `f5f635a8` records its own intent: *"15 files missing YAML frontmatter repaired with path-derived metadata (contributor marked @backfill-needed for credit restoration from git history)"*.

**The files were not missing frontmatter.** Fourteen were missing only the opening `---` delimiter. One (`s04/04.md`) was missing both. A complete generated block was prepended instead of a delimiter being added, which shadowed metadata the contributor had written correctly and replaced their name with a placeholder.

The `@backfill-needed` marker was left as an explicit TODO. This PR is that TODO, done from git history as intended.

## What this changes

**Removal of the generated block and restoration of the missing delimiters. Nothing else.**

- Syllabus bodies are **byte-identical to main**, asserted per file.
- Headings are identical, asserted per file.
- No course title, semester placement or university fact is edited.

**Attribution comes from git history, not from the shadowed block.** `sandra07alex` authored all fifteen files across 45 commits. One file spells the handle `@sandrao7alex`; that account returns 404 on GitHub while `Sandra07alex` exists, and git names `sandra07alex` as the author of both commits touching it. Corrected there and only there. GitHub handles only, no email addresses.

**Thirteen course codes come back as a side effect.** They were in the file all along, under the generated block. This is recovered contributor content, not new extraction and not inference.

**Two codes are left wrong on purpose.** `s03/06.md` recovers `pccsl305` and `s03/07.md` recovers `pccsl307`. Both are genuinely wrong against the official CSD syllabus. Correcting them is a sourced data change and belongs in its own PR, so they stay as the contributor wrote them.

## The validator rule

One rule, deliberately strict, because `---` is also a Markdown horizontal rule and **1,020 files use one in their body**. A naive detector would flag every one of them.

A candidate qualifies only when it sits immediately after the first block (ignoring blank lines), closes at a line whose entire trimmed content is exactly `---`, lies outside fenced code, contains no blank lines, and carries every required field exactly once.

Two conditions were stated loosely in the first commit and corrected in `fd3c86b1`:

- The closing delimiter was matched with `find("\n---")`, which also accepts `----`, `---text` and `--- # comment`. Three false positives.
- Blank lines were skipped with `lstrip("\n")`, which does not treat a line of spaces or tabs as blank. One false negative.

Both were verified against the previous implementation before being fixed. The rule is now written line by line rather than by string offsets, which is what made the loose conditions easy to write in the first place.

Measured against real data:

| | Result |
|---|---|
| Fires on the 15 files as they are on `main` | **14 / 15** |
| Fires after this repair | **0 / 15** |
| Fires on the 1,020 files with a horizontal rule in the body | **0** |
| Fires anywhere in the repository after this repair | **0** |

**`s04/04.md` is the one it does not catch.** Its shadowed block was never terminated by a `---`, so it fails the "closes at a standalone delimiter" condition. It was found by reading `f5f635a8`, not by the rule. Widening the rule to reach it would mean guessing where unterminated prose ends, so the rule stays narrow and this note stands in for the gap.

## Tests

`scripts/tests/test_shadowed_frontmatter.py`, wired into CI ahead of the validator. Scope is this rule only, not a general suite. No new dependencies.

```
PASS  the real defect: a generated block shadowing the original
PASS  a legitimate file with one frontmatter block
PASS  a horizontal rule in the body
PASS  a fenced example containing ---
PASS  body prose starting with 'country:' then a later horizontal rule
PASS  an incomplete YAML-like block (missing required fields)
PASS  a second block with a duplicated field
PASS  a second block containing a blank line
PASS  a file with no frontmatter at all
PASS  blank lines between the two blocks are still the defect
PASS  a metadata-shaped body closed by ---- is not a delimiter
PASS  a metadata-shaped body closed by ---text is not a delimiter
PASS  a metadata-shaped body closed by '--- # comment' is not a delimiter
PASS  whitespace-only lines between the blocks are still blank
PASS  a fenced yaml example immediately after the frontmatter

15/15 passed
```

## Existing behaviour preserved

Every existing rule and severity is unchanged.

```
before (main):  checked 2228 file(s): 0 error(s), 671 warning(s)
after:          checked 2228 file(s): 0 error(s), 671 warning(s)
```

## Commits

| SHA | Contents |
|---|---|
| `0c31d165` | the 15-file data repair, approved and unchanged since |
| `fd3c86b1` | validator and test corrections only, no data files touched |

## Relationship to PR #200

**#200 is untouched and remains open.** This branch was cut fresh from `main`, not from #200 and not rebased onto it.

Reviewing #200 is what surfaced this defect. Worth knowing when you come to it: 13 of the 15 CSD course codes #200 corrected from the official PDF were already present in these files, hidden by the shadowing block. #200's disposition is a separate decision.