### PR TITLE
Correct KTU CSE PECST742 course title from official 2024 syllabus

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science/2024/s07/02.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science/2024/s07/02.md
@@ -5,12 +5,12 @@ branch: "cse"
 version: "2024"
 semester: "7"
 course_code: "pecst742"
-course_title: "web-development-technologies"
+course_title: "web-programming"
 language: "english"
 contributor: "@Sharx05"
 ---
 
-# PECST742 : Web Development Technologies
+# PECST742: Web Programming
 
 ## Course Objectives
 


### PR DESCRIPTION
## The correction

`computer-science/2024/s07/02.md` carries the title **Web Development Technologies**. The official KTU syllabus names the course **Web Programming**.

```diff
-course_title: "web-development-technologies"
+course_title: "web-programming"

-# PECST742 : Web Development Technologies
+# PECST742: Web Programming
```

One file, two lines. No other field, and no character of the syllabus body, is touched.

## Source

**There is no stable PDF permalink.** KTU delivers syllabus documents through a session-bound `POST` to `api.ktu.edu.in/ktu-web-portal-api/service/anon/getAttachments`, which the browser renders as a `blob:` URL. The evidence is therefore a reproducible navigation procedure plus hashes, not a link.

**Navigation, performed 2026-07-31:**

```
https://ktu.edu.in/academics/scheme
  row  "B.TECH FULL TIME 2024 SCHEME | Full Time | Started Year: 2024 - 2025"
  → Branch
https://ktu.edu.in/academics/branch
  row  "COMPUTER SCIENCE AND ENGINEERING | Full Time | Started Year: 2024 - 2025
        | Cluster/University: APJ Abdul Kalam Technological University"
  → Syllabus
https://ktu.edu.in/academics/syllabus
  header  "COMPUTER SCIENCE AND ENGINEERING"        ← checked before downloading
  tab     LATEST SYLLABUS
  entry   "S3-S8COMPUTERSCIENCEANDENGINEERINGFINALSYLLABUS"
          "Updated Date  Monday, March 2, 2026"
  → Syllabus (download)
```

| | |
|---|---|
| Publisher | APJ Abdul Kalam Technological University |
| Document | S3-S8 Computer Science and Engineering Final Syllabus |
| Curriculum version | B.Tech Full Time 2024 Scheme |
| Listing status | Current, under LATEST SYLLABUS, amended 2026-03-02 |
| Retrieved | 2026-07-31T05:32:30Z |
| Pages | 450 |
| PDF producer | GPL Ghostscript 10.02.1, created 2025-11-03 |

**Hashes**

| | |
|---|---|
| `raw_response_size` | 2,813,905 bytes |
| `raw_response_sha256` | `27e350893820f564d8890c63cb05d9c1cf81f0f94b60edb803847a51120bbe93` |
| `pdf_payload_size` | 2,813,903 bytes |
| `pdf_payload_sha256` | `e4997e885fe1100a57d1679c85e9d2680a706dca99b6c8aee79fffa0e78e152f` |

The served response is the PDF payload followed by exactly two bytes, `0d 0a`, after the terminal `%%EOF` line. The payload's final bytes are `%%EOF` + LF, and nothing but that CRLF follows. The raw files are **not** byte-identical to the previously recorded artefact; the **PDF payload is** byte-identical, and the raw response carries one additional trailing CRLF.

**Accepting that envelope difference was an explicit human decision for this retrieval.** It is not a general licence to normalise, trim or rewrite PDFs, and no local artefact was modified.

## Page evidence

PDF page index **310**. No printed page number appears on that page.

```
SEMESTER S7
WEB PROGRAMMING
(Common to CS/CA/CM/CD/CR/AD/AM)
Course Code                PECST742      CIE Marks    40
Teaching Hours/Week (L: T:P: R)  3:0:0:0  ESE Marks    60
```

- Code confirmed: `PECST742`
- Official title confirmed verbatim: **WEB PROGRAMMING**
- Branch applicability: the "(Common to …)" line includes **CS**
- Semester: the document's own **SEMESTER S7** section banner, matching the record's existing `semester: 7` and its `s07/` folder

`PECST742` occurs exactly once in the whole document.

**Placement caveat, disclosed.** The KTU curriculum-placement table for CSE (`ktu.edu.in/academics/CurriculamDetails`) does **not** corroborate this. That table lists 9 to 20 rows for Semesters 1 to 5, **omits Semester 6 entirely**, and shows a single row each for Semesters 7 and 8. It does not enumerate elective groups, and "WEB PROGRAMMING" appears nowhere in it. Its silence reflects that incompleteness, not a placement doubt. Placement rests on the syllabus document's S7 section banner. **This PR changes no placement field**, so it asserts no new placement claim.

## Repository checks

| Check | Result |
|---|---|
| `PECST742` records in CSE 2024 | 1, no duplicate |
| Stronger or independently sourced CSE record | none; no file in CSE 2024 carries `provenance` |
| `web-development-technologies` elsewhere | none |
| Contributor | `@Sharx05`, unchanged |

**After this change, two CSE 2024 records share the title `web-programming`:** `s07/02.md` (`pecst742`, S7) and `s08/11.md` (`oecst832`, S8). Both are named WEB PROGRAMMING in the official document, at pages 310 and 437. They are different courses.

This is the normal pattern in this branch, not an anomaly. Eleven title pairs in CSE 2024 work the same way, a programme elective and an open elective sharing an official name:

```
software-engineering            pecst411 (S4)  /  oecst723 (S7)
computer-networks               pccst501 (S5)  /  oecst724 (S7)
cloud-computing                 pecst635 (S6)  /  oecst722 (S7)
software-testing                pecst631 (S6)  /  oecst833 (S8)
mobile-application-development  pecst695 (S6)  /  oecst725 (S7)
internet-of-things              pecst755 (S7)  /  oecst834 (S8)
web-programming                 pecst742 (S7)  /  oecst832 (S8)   ← this PR
```

The correction makes `s07/02.md` consistent with that pattern rather than creating a collision.

## Pre-existing issue left outside this PR

`s07/02.md` carries `branch: "cse"` while its folder is `computer-science`, producing a validator warning. All 98 CSE files do this and it is tracked in #198. Not touched here.

Also unchanged and still unresolved: the Coding Theory duplication in `s04/08.md` and `s04/19.md`, deliberately excluded.

## Scope statement

This is a **field-level title correction only**. The contributor-written objectives, modules and references are preserved byte for byte. **This PR does not independently verify or endorse that syllabus body.** A green check here means the title now matches the official document, nothing more.

## Verification

```
git diff --check                    clean
focused tests                       15/15 passed
python3 scripts/validate.py         checked 2228 file(s): 0 error(s), 671 warning(s)
                                    (identical to main)
diff assertion                      PASS: 1 file, exactly 2 lines removed, 2 added
duplicate code scan (CSE 2024)      pecst742 count = 1
```