### PR TITLE
Repair cross-repository syllabus sync

### DIFF
--- a/.github/workflows/sync-universities.yml
+++ b/.github/workflows/sync-universities.yml
@@ -1,5 +1,8 @@
 name: Sync Syllabus
 
+# Regenerates Beyond-Syllabus's syllabus.json from this repository and opens a
+# pull request against it. It never pushes to either default branch, so the
+# generated data goes through Beyond-Syllabus's own CI before anyone merges it.
 on:
   push:
     paths:
@@ -7,45 +10,141 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 */6 * * *' 
-      
+    # Off the hour: minute zero is the busiest slot on shared runners.
+    - cron: '17 */6 * * *'
   workflow_dispatch:
+
+# Only ever reads this repository. Everything written to Beyond-Syllabus is
+# authorised by the App installation token, not by this workflow's token.
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-syllabus
+  cancel-in-progress: true
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Replaces the old shell fork-check, which called `exit 0` and so let every
+    # later step run anyway. Forks and non-default branches never reach the
+    # App token.
+    if: >-
+      github.repository == 'The-Purple-Movement/WikiSyllabus' &&
+      github.ref == 'refs/heads/main'
 
     steps:
-      - name: Check if the repository is a fork
-        run: |
-          if [[ "${GITHUB_REPOSITORY}" != "The-Purple-Movement/WikiSyllabus" ]]; then
-            echo "This workflow does not run on forks."
-            exit 0
-          fi
+      - name: Checkout WikiSyllabus at the triggering commit
+        uses: actions/checkout@v5
+        with:
+          # Pinned to the exact SHA so a rerun regenerates the same output,
+          # unlike the old `bun sync`, which cloned whatever main happened to be.
+          ref: ${{ github.sha }}
+          path: wikisyllabus
+          persist-credentials: false
 
-      - name: Checkout Beyond-Syllabus repository
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.SYLLABUS_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYLLABUS_SYNC_APP_PRIVATE_KEY }}
+          owner: The-Purple-Movement
+          repositories: Beyond-Syllabus
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout Beyond-Syllabus
         uses: actions/checkout@v5
         with:
           repository: The-Purple-Movement/Beyond-Syllabus
           ref: main
-          token: ${{ secrets.GH_TOKEN }}
+          path: beyond-syllabus
+          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Matches packageManager in Beyond-Syllabus/package.json. The old
+          # workflow ran `npm install` then `npm run patch`, and `patch` shells
+          # out to bun, so it could not have worked on a Node-only runner.
+          bun-version: 1.2.12
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install Beyond-Syllabus dependencies
+        working-directory: beyond-syllabus
+        run: bun install --frozen-lockfile
 
-      - name: Run update script
-        run: npm run patch
-
-      - name: Set up Git config
+      - name: Stage syllabus data from the pinned WikiSyllabus checkout
         run: |
-          git config --global user.name "alvin-dennis"
-          git config --global user.email "alvindennis80@gmail.com"
+          rm -rf beyond-syllabus/universities
+          cp -R wikisyllabus/universities beyond-syllabus/universities
 
-      - name: Push Changes
+      - name: Generate syllabus.json
+        working-directory: beyond-syllabus
+        # `bun run generate` directly, not `bun run patch`: patch would re-clone
+        # WikiSyllabus at an unpinned main and discard the SHA checked out above.
+        run: bun run generate
+
+      - name: Remove the staged syllabus data
+        run: rm -rf beyond-syllabus/universities
+
+      - name: Assert only the generated file changed
+        working-directory: beyond-syllabus
         run: |
-          git add apps/server/src/routes/syllabus/syllabus.json
-          git commit -m "chore: Updated syllabus.json from WikiSyllabus" || echo "No changes to commit"
-          git push origin main
+          git status --porcelain > /tmp/sync-status.txt
+          cat /tmp/sync-status.txt
+          # Collect the lines that are NOT the one allowed change, rather than
+          # relying on grep's exit code: BSD and GNU grep disagree on what -q
+          # returns for an empty input.
+          unexpected=$(grep -v '^ M apps/server/src/routes/syllabus/syllabus\.json$' /tmp/sync-status.txt || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected changes outside the generated file"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Stop early if the generated data is unchanged
+        id: diff
+        working-directory: beyond-syllabus
+        run: |
+          if git diff --quiet -- apps/server/src/routes/syllabus/syllabus.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Syllabus data is already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update the Beyond-Syllabus pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: beyond-syllabus
+          # The App token, not GITHUB_TOKEN: a pull request opened with
+          # GITHUB_TOKEN does not fire `pull_request` workflows, so
+          # Beyond-Syllabus CI would never validate the generated data.
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          branch: automation/sync-wikisyllabus
+          add-paths: apps/server/src/routes/syllabus/syllabus.json
+          commit-message: |
+            chore: regenerate syllabus.json from WikiSyllabus
+
+            Source: The-Purple-Movement/WikiSyllabus@${{ github.sha }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          title: 'chore: sync syllabus.json from WikiSyllabus'
+          body: |
+            Regenerated `apps/server/src/routes/syllabus/syllabus.json` from WikiSyllabus.
+
+            **Source commit:** `The-Purple-Movement/WikiSyllabus@${{ github.sha }}`
+
+            Produced by `bun run generate` on Bun 1.2.12 against the
+            `universities/` tree at exactly that commit. Generation is
+            deterministic for a given source commit.
+
+            This branch is reused: each sync updates it in place rather than
+            opening a new pull request.
+
+            Opened automatically by `Sync Syllabus` in WikiSyllabus.
+          labels: automated, syllabus-sync
+          delete-branch: false


### PR DESCRIPTION
## A nine-month downstream outage

`Sync Syllabus` has failed **200 of its last 200 runs**. The last success was `2025-11-08T07:27:40Z`, and `syllabus.json` in Beyond-Syllabus was last updated `2025-11-08T07:28:32Z` (`31c9f5cb`).

Beyond-Syllabus has been serving students data from November while WikiSyllabus moved on.

## Why it failed

Every run died at the same step, before any generation:

```
success  Check if the repository is a fork
failure  Checkout Beyond-Syllabus repository     ← first failing step
skipped  Set up Node.js
skipped  Install dependencies
skipped  Run update script
skipped  Push Changes
```

```
git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

`secrets.GH_TOKEN` was last updated `2025-08-05` and stopped being accepted around `2025-11-08`. The secret still exists; its value was never read or tested in this investigation.

**Branch protection was never the cause.** Beyond-Syllabus has no rulesets and no classic branch protection.

## Fixing the token alone would not have worked

Two further defects sat behind it:

| Workflow did | Beyond-Syllabus declares |
|---|---|
| `actions/setup-node@v4`, `npm install`, `npm run patch` | `packageManager: "bun@1.2.12"`; `patch` = `bun sync && bun run generate` |

`npm run patch` shells out to `bun` on a runner where bun was never installed. It would have failed a few steps later.

And `bun sync` does `git clone --depth 1 …/WikiSyllabus.git`, pinning nothing. Output never corresponded to the commit that triggered the run.

## What changed

**Bun, pinned.** `oven-sh/setup-bun@v2` at `1.2.12`, then `bun install --frozen-lockfile`.

**Source pinned to the exact SHA.** WikiSyllabus is checked out at `${{ github.sha }}` into its own directory with `persist-credentials: false`. Its `universities/` tree is copied into Beyond-Syllabus, `bun run generate` runs directly, and the copy is removed afterwards.

**`bun sync` is not used** because it would re-clone WikiSyllabus at an unpinned `main` and discard the SHA just checked out. Neither is `npm install`, `npm run patch`, or `bun run patch`.

**No direct push to any `main`.** The generated file goes into a pull request against Beyond-Syllabus, so its own CI validates the data before merge. This is a deliberate change from the previous behaviour, which pushed straight to `Beyond-Syllabus/main`.

**Fixed branch**, `automation/sync-wikisyllabus`, updated in place by `peter-evans/create-pull-request@v8`. One PR, refreshed, not one per sync.

**Dedicated GitHub App**, scoped by `actions/create-github-app-token@v3` to owner `The-Purple-Movement`, repository `Beyond-Syllabus`, permissions `contents: write` and `pull-requests: write`. No `GH_TOKEN`, no `PERSONAL_TOKEN`, no ruleset bypass, no personal identity.

**The App token also opens the PR**, and this matters: a pull request created with `GITHUB_TOKEN` does not fire `pull_request` workflows, so Beyond-Syllabus CI would never run on it.

**Bot identity.** Commits as `github-actions[bot]`, replacing the hardcoded personal name and email.

**Concurrency.** Group `sync-syllabus`, `cancel-in-progress: true`. The 6-hourly schedule and push-triggered runs can no longer race, a failure mode already observed in the sibling contributors workflow.

**Schedule moved off minute zero**, `17 */6 * * *`.

**Fork check replaced.** The old step called `exit 0` on a fork, which ends that step successfully and lets every later step run anyway. It is now a job-level condition on both repository and ref.

**Least privilege.** Workflow `permissions: contents: read`. Every write is authorised by the App token.

**Scope assertion**, and a clean no-op path: if the generated file is unchanged, the job succeeds without opening a PR.

## Verification

Performed locally on **Bun 1.2.12** from `WikiSyllabus@ec9b613d` against `Beyond-Syllabus@b25781fa`, in temporary clean checkouts. Nothing was pushed to Beyond-Syllabus.

| | |
|---|---|
| `bun install --frozen-lockfile` | exit 0, 605 packages |
| Generation run 1 | 12,795,322 bytes, `c796b7be69d79f96c9abb8713aaa30bd8fbbcd416d471ed782ec7543cd7292d3` |
| Generation run 2 | identical |
| **Determinism** | **byte-identical, PASS** |
| Currently committed downstream | 12,582,928 bytes, `11b93013507146a590b516b8346b82397187dd9079ca3915363fc866aeffe80a` |

Beyond-Syllabus CI command sequence, run against the regenerated data:

```
bun run check        (oxlint)     exit 0   12 warnings, 0 errors
bun run check-types              exit 0
bun run test         TZ=Asia/Kolkata   exit 0   1 task successful
bun run build        placeholder env    exit 0   2 tasks successful
```

Build env matched CI: `NEXT_PUBLIC_SERVER_URL=http://localhost:3000`, `UPSTASH_REDIS_URL=https://placeholder.upstash.io`, `UPSTASH_REDIS_TOKEN=placeholder`.

Target-repo scope: `git status --porcelain` showed exactly `M apps/server/src/routes/syllabus/syllabus.json`.

## The pending downstream update

| | Committed | Regenerated |
|---|---|---|
| Universities | 18 | 18 |
| Programmes | 49 | 50 |
| Schemes | 61 | 62 |
| Semesters | 303 | 307 |
| **Subjects** | **2,197** | **2,225** |

`iisc` → `iisc-bengaluru` (the #197 rename) has not propagated. And KTU CS 2024 Semester 4 downstream still lists `pccst402` **twice**, the duplicate removed in #203, while missing `pccsl407`, `pccsl408` and `pecst414` entirely.

## Owner setup required before this can run

1. Create a GitHub App under `The-Purple-Movement` with repository permissions `Contents: Read and write` and `Pull requests: Read and write`.
2. Install it on **Beyond-Syllabus** only.
3. In WikiSyllabus, add repository **variable** `SYLLABUS_SYNC_APP_CLIENT_ID` (the App's Client ID) and **secret** `SYLLABUS_SYNC_APP_PRIVATE_KEY` (the App's private key, PEM).
4. Run `Sync Syllabus` via `workflow_dispatch` and confirm a PR opens on Beyond-Syllabus with CI running on it.
5. Once green, `GH_TOKEN` can be removed from WikiSyllabus; nothing references it after this change.

Until step 3 is done the workflow will fail at the token step. That is a visible, honest failure rather than the silent staleness of the last nine months.

## Rollback

Revert this single file. No data is affected: `syllabus.json` is generated, and nothing has been written to Beyond-Syllabus.

## Out of scope

`Generate Contributors List` is **untouched**. Its ruleset-blocked push remains open and is a separate decision.