### PR TITLE
fix(csd): s03/07 is PCCSL308 Digital Lab, not PCCSL307 Digital Systems Lab

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/07.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/07.md
@@ -4,29 +4,112 @@ university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"
 semester: 3
-course_code: "pccsl307"
-course_title: "digital-systems-lab"
+course_code: "pccsl308"
+course_title: "digital-lab"
 language: "english"
-contributor: "@sandra07alex"
+contributor: "@deepusnath"
+contributors: ["deepusnath", "sandra07alex"]
+provenance: "extracted-from-official-pdf"
+source: "KTU B.Tech Full Time 2024 Scheme, official branch syllabus PDF"
 ---
 
-# PCCSL307: Digital Systems Lab
+# PCCSL308: Digital Lab
+
+**Course type:** Lab · **Credits:** 2 · **Common to CS/CM/AM/CN**
 
 ## Course Objectives
-* To introduce digital logic components and implement basic combinational and sequential circuits.
+
+1. To enable the learner to design and implement basic digital logic circuits using logic gates and ICs.
+2. To familiarize digital system design using HDL.
+
+## Experiments
+
+All HDL based experiments should be done using Verilog HDL. At least three experiments of Part A and Part B together should be implemented on a breadboard. Use any open source circuit simulation software or web based logic simulator for the rest, for example [circuitverse.org](https://circuitverse.org), [simulator.io](https://simulator.io) or [logiccircuit.org](https://www.logiccircuit.org).
+
+### Part A
+
+All experiments in this part are mandatory. They introduce digital design by familiarising the basic gates and combinational circuits on breadboard or circuit simulation software, along with their HDL based realisation.
+
+**A1.** Study of basic digital ICs and verification of Boolean theorems using digital logic gates.
+
+**A2.** Familiarisation of the working of circuit simulation software.
+- Realize the basic logic gates and analyze their waveforms
+- Realize a given Boolean function using basic gates and verify the waveform with the truth table
+
+**A3.** Familiarisation of Verilog HDL. Modelling of the basic gates using
+- gate level modelling
+- behavioural modelling
+- structural modelling
+- dataflow modelling
+
+**A4.** Realization of an SOP and its corresponding POS expression using NAND gates alone and NOR gates alone. To be done on breadboard and simulated using software.
+
+**A5.** Model a given Boolean function (SOP and POS) in Verilog using
+- continuous assignment with logical operators
+- continuous assignment with conditional operators
+- gate level primitives
+
+### Part B
+
+All experiments to be done using any circuit simulation software.
+
+**B1.** Design and implement a combinational logic circuit for arbitrary functions (any two)
+- Code converters
+- Half adder, full adder, half subtractor, full subtractor
+- Multiplexer, Demultiplexer, Encoder, Decoder
+
+**B2.** Design and implement combinational circuits using MSI devices (any three)
+- 4-bit adder and subtractor using MSI device IC 7483
+- Parity generator / checker using MSI device IC 74180
+- Magnitude Comparator using MSI device IC 7485
+- Implement a boolean function using MUX IC
+
+**B3.** Study of D flip flop and JK flip flops using ICs.
+
+**B4.** Design and implement the following shift registers using D flip flops
+- Serial in serial out
+- Serial in parallel out
+- Parallel in serial out
+- Parallel in parallel out
+
+**B5.** Design and implement an asynchronous counter: 3 bit up counter, 3 bit down counter, 3 bit up down counter with mode control, mod-N counter.
+
+**B6.** Design and implement a synchronous counter: 3 bit up counter, 3 bit down counter, sequence generator.
+
+### Part C
+
+Using Verilog HDL. For all experiments in this part:
+
+1. Write Verilog program code in the IDE or software. Other open source or online software such as Icarus Verilog or EDAplayground may be used.
+2. Simulate the code using a test bench or by giving input values.
+3. Synthesize the design and verify the waveforms.
+
+**C1.** Model a 4:1 MUX, 1:4 DEMUX, 4 to 2 encoder, 2 to 4 decoder and a 7-Segment Display Decoder in Verilog using
+- continuous assignment with logical operators
+- continuous assignment with conditional operators
+
+**C2.** Design and synthesize the behavioural model for a D flip flop in Verilog HDL.
+
+**C3.** Design and synthesize the behavioural model for a synchronous counter in Verilog.
+
+**C4.** Design a Verilog HDL behavioral model to implement a finite-state machine, a serial bit sequence detector.
 
 ## Course Outcomes
-* **CO1:** Analyze digital circuit function and applications[K4].
-* **CO2:** Design small-scale digital systems using standard ICs and FPGAs[K3].
 
-## Course Content
+At the end of the course students should be able to:
 
-* Logic gates, universal gates
-* Adders, subtractors, multiplexers, code converters
-* Flip-flops, counters, registers, implementation using ICs and simulation
-* Simple combinational/sequential circuits design using HDL tools
-* Mini-project (e.g., traffic light controller, digital clock)
+- **CO1:** Model and construct combinational logic circuits [K3]
+- **CO2:** Develop modular combinational circuits with MUX, DEMUX and decoder [K3]
+- **CO3:** Experiment with synchronous and asynchronous sequential circuits [K3]
+- **CO4:** Model and implement FSM [K3]
 
-## References
-- Digital Design by Morris Mano, Pearson, 6e, 2017
-- Lab manual and department provided hardware guides
+## Text Books
+
+- *Introduction to Logic Circuits & Logic Design with Verilog* – Brock J. LaMeres, Springer International Publishing, 2/e, 2017
+- *Digital Design and Computer Architecture, RISC-V Edition* – Sarah L. Harris, David Harris, Morgan Kaufmann, 1/e, 2022
+- *Verilog HDL Synthesis: A Practical Primer* – J Bhasker, Star Galaxy Publishing, 1/e, 1998
+
+## Reference Books
+
+- *Digital Design with an Introduction to the Verilog HDL, VHDL, and System Verilog* – M Morris Mano, Michael D Ciletti, Pearson, 6/e, 2018
+- *Fundamentals of Digital Logic with Verilog Design* – Stephen Brown, Zvonko Vranesic, McGrawHill, 3/e, 2014


### PR DESCRIPTION
Step 1 of 4 in the CSD Semester 3 correction. **This one must land before the others**, because `pccsl307` is currently occupying this file and step 2 moves it onto `s03/06.md`. Landing them in the other order would put two files on the same course code.

## Evidence

Source: KTU B.Tech Full Time 2024 Scheme, official Computer Science and Design syllabus PDF, 398 pages, supplied by the university.

The document's Semester 3 block runs from line 1 to line 2147, where Semester 4 begins. Both labs sit inside it:

```
1638  Course Code  PCCSL307   DATA STRUCTURES LAB
1882  Course Code  PCCSL308   DIGITAL LAB  (Common to CS/CM/AM/CN)
```

`PCCSL305` appears **zero times** in the document. So does the title "Digital Systems Lab".

## What changed

| | Before | After |
|---|---|---|
| `course_code` | pccsl307 | **pccsl308** |
| `course_title` | digital-systems-lab | **digital-lab** |

## Scope note: the body was replaced too, not just the two fields

I planned a two-field edit. On reading the file, the body turned out not to be an extraction at all:

- no CIE/ESE marks, no credits, no teaching hours, no course type
- no experiment list, just five summary bullets under "Course Content"
- "Lab manual and department provided hardware guides" as a reference

Correcting only the code and title would have left an invented record wearing an official course code, which is worse than an obviously wrong one: it would look authoritative to a student.

The body is now extracted from the document: the stated objectives, the full Part A / Part B / Part C experiment list, the four course outcomes with Bloom levels, and the real text and reference books.

## Attribution

`@sandra07alex` wrote the original record and is retained in `contributors`. The `contributor` field follows the precedent set in #203 for curated extractions.

## Validation

```
checked 1 file(s): 0 error(s), 0 warning(s)
```

Also confirmed: no shadowed frontmatter, no em dashes.

## Not in this PR

- `s03/06.md`: `pccsl305` → `pccsl307` (step 2, depends on this one)
- `GAEST305` Digital Electronics and Logic Design, a real S3 course with no file at all (step 3)
- `s03/08.md` `oecs301`, which appears zero times in the document and has the same unsourced shape as this file did. Awaiting a decision on whether to ask the contributor for a source or remove it.