### PR TITLE
fix(csd): s03/06 is PCCSL307 Data Structures Lab, not PCCSL305

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/06.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/06.md
@@ -4,32 +4,63 @@ university: "ktu"
 branch: "computer-science-and-design"
 version: "2024"
 semester: 3
-course_code: "pccsl305"
+course_code: "pccsl307"
 course_title: "data-structures-lab"
 language: "english"
-contributor: "@sandra07alex"
+contributor: "@deepusnath"
+contributors: ["deepusnath", "sandra07alex"]
+provenance: "extracted-from-official-pdf"
+source: "KTU B.Tech Full Time 2024 Scheme, official branch syllabus PDF"
 ---
 
-# PCCSL305: Data Structures Lab
+# PCCSL307: Data Structures Lab
+
+**Course type:** Lab · **Credits:** 2 · **Prerequisite:** GYEST204
+
+Common to CS/CA/CM/CD/CR/AI/AM/AD/CB/CN/CC/CU/CI/CG.
 
 ## Course Objectives
-* To implement linear and nonlinear data structures and fundamental algorithms in a practical setting.
-* To develop programming ability using C/C++/Java and strengthen debugging and documentation.
+
+1. To give practical experience for learners on implementing different linear and non linear data structures, and algorithms for searching and sorting.
+
+## Experiments
+
+1. Find the sum of two sparse polynomials using arrays.
+2. Find the transpose of a sparse matrix and sum of two sparse matrices.
+3. Convert infix expression to postfix (or prefix) and then evaluate using stack.
+4. Implement Queue, DEQUEUE, and Circular Queue using arrays.
+5. Implement backward and forward navigation of visited web pages in a web browser, that is the back and forward buttons, using doubly linked list operations.
+6. Implement addition and multiplication of polynomials using singly linked lists.
+7. Create a binary tree for a given simple arithmetic expression and find the prefix / postfix equivalent.
+8. Implement a dictionary of word-meaning pairs using binary search trees.
+9. Find the shortest distance of every cell from a landmine inside a maze.
+10. We have three containers whose sizes are 10 litres, 7 litres, and 4 litres, respectively. The 7-litre and 4-litre containers start out full of water, but the 10-litre container is initially empty. We are allowed one type of operation: pouring the contents of one container into another, stopping only when the source container is empty or the destination container is full. We want to know if there is a sequence of pourings that leaves exactly 2 litres in the 7 or 4-litre container. Model this as a graph problem and solve.
+11. Implement the find and replace feature in a text editor.
+12. Given an array of sorted items, implement an efficient algorithm to search for a specific item in the array.
+13. Implement Bubble sort, Insertion Sort, Radix sort, Quick Sort, and Merge Sort and compare the number of steps involved.
+14. The General post office wishes to give preferential treatment to its customers. They have identified the customer categories as Defence personnel, Differently abled, Senior citizen, Ordinary. The customers are to be given preference in the decreasing order: Differently abled, Senior citizen, Defence personnel, Normal person. Generate the possible sequence of completion.
+15. Implement a spell checker using a hash table to store a dictionary of words for fast lookup. Implement functions to check if a word is valid and to suggest corrections for misspelled words.
+16. Simulation of a basic memory allocator and garbage collector using doubly linked list.
+17. The CSE dept is organizing a tech fest with so many exciting events. By participating in an event, you can claim for activity points as stipulated by KTU. Each event i gives you A[i] activity points where A is an array. If you are not allowed to participate in more than k events, what is the max number of points that you can earn?
+18. Merge K sorted lists into a single sorted list using a heap. Use a min-heap to keep track of the smallest element from each list. Repeatedly extract the smallest element and insert the next element from the corresponding list into the heap until all lists are merged.
 
 ## Course Outcomes
-* **CO1:** Implement data structure operations with code[K3].
-* **CO2:** Select and justify structures/algorithms for real tasks[K3].
-* **CO3:** Analyze time/space complexity experimentally[K4].
 
-## Course Content
+At the end of the course students should be able to:
 
-* Array, stack, queue implementation
-* Linked list (single, double, circular)
-* Trees (binary, search, traversal)
-* Graph storage, BFS/DFS traversal
-* Sorting (bubble, selection, insertion, merge, quick), searching, and hashing implementation
-* Mini-project based on applications of data structures
+- **CO1:** Model a real world problem using suitable data structure and implement the solution [K3]
+- **CO2:** Compare efficiency of different data structures in terms of time and space complexity [K4]
+- **CO3:** Evaluate the time complexities of various searching and sorting algorithms [K5]
+- **CO4:** Differentiate static and dynamic data structures in terms of their advantages and application [K3]
 
-## References
-- Lab manual as prepared from: Horowitz/Sahni, Fundamentals of Data Structures in C, 2e, 2007
-- Cormen et al., Introduction to Algorithms, 3e, 2009
+## Text Books
+
+- *Fundamentals of Data Structures in C* – Ellis Horowitz, Sartaj Sahni, Susan Anderson-Freed, Universities Press, 2/e, 2007
+- *Introduction to Algorithms* – Thomas H Cormen, Charles Leisesrson, Ronald L Rivest, Clifford Stein, PHI, 3/e, 2009
+
+## Reference Books
+
+- *Classic Data Structures* – Samanta D., Prentice Hall India, 2/e, 2018
+- *Data Structures and Algorithms* – Aho A. V., J. E. Hopcroft, J. D. Ullman, Pearson Publication, 1/e, 2003
+- *Introduction to Data Structures with Applications* – Tremblay J. P., P. G. Sorenson, Tata McGraw Hill, 2/e, 2017
+- *Theory and Problems of Data Structures* – Lipschutz S., Schaum's Series, 2/e, 2014


### PR DESCRIPTION
Step 2 of 4 in the CSD Semester 3 correction. Depends on #207, which is merged, so `pccsl307` is free.

## Evidence

Source: KTU B.Tech Full Time 2024 Scheme, official Computer Science and Design syllabus PDF.

```
1638  Course Code  PCCSL307   DATA STRUCTURES LAB
      (Common to CS/CA/CM/CD/CR/AI/AM/AD/CB/CN/CC/CU/CI/CG)
      Credits 2 · Prerequisite GYEST204 · Course Type Lab
```

`PCCSL305` appears **zero times** in the document.

## What changed

| | Before | After |
|---|---|---|
| `course_code` | pccsl305 | **pccsl307** |
| `course_title` | data-structures-lab | unchanged, already correct |

## Body replaced, same reason as #207

This file had the same unsourced shape: no marks, no credits, no prerequisite, no experiment list, six summary bullets under "Course Content", and "Lab manual as prepared from..." as a reference.

It now carries the official record: the stated objective, all **18 experiments** verbatim, four course outcomes with Bloom levels, and the real text and reference books.

## Duplicate check

Verified on the branch, every file in `s03/`:

```
01.md  gamat301      05.md  uchut347
02.md  pccst302      06.md  pccsl307   ← this PR
03.md  pccst303      07.md  pccsl308   ← #207
04.md  pbcst304      08.md  oecs301
```

Each lab code appears exactly once. The ordering hazard is now cleared.

## Validation

```
checked 1 file(s): 0 error(s), 0 warning(s)
```

No shadowed frontmatter, no em dashes.

## Remaining in this series

- **Step 3:** `GAEST305` Digital Electronics and Logic Design, a real S3 course at document line 908 with no file in the repo
- **Step 4:** ECE `s03/06.md` and Chemical `s03/05.md`, `engineering-economics` → `economics-for-engineers`
- **Open:** `s03/08.md` `oecs301`, which appears zero times in the document