### PR TITLE
feat(csd): add GAEST305 Digital Electronics and Logic Design (missing S3 course)

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/09.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2024/s03/09.md
@@ -1,0 +1,78 @@
+---
+country: "india"
+university: "ktu"
+branch: "computer-science-and-design"
+version: "2024"
+semester: 3
+course_code: "gaest305"
+course_title: "digital-electronics-and-logic-design"
+language: "english"
+contributor: "@deepusnath"
+provenance: "extracted-from-official-pdf"
+source: "KTU B.Tech Full Time 2024 Scheme, official branch syllabus PDF"
+---
+
+# GAEST305: Digital Electronics and Logic Design
+
+**Course type:** Theory · **Credits:** 4 · **Teaching hours/week (L:T:P:R):** 3:1:0:0
+
+Common to Group A. No prerequisites.
+
+## Course Objectives
+
+- To familiarize the basic concepts of Boolean algebra and digital systems.
+- To enable the learner to design simple combinational and sequential logic circuits which is essential in understanding organization and design of computer systems.
+
+## Course Modules
+
+### Module 1 (11 hours)
+
+**Introduction to digital Systems:** Digital abstraction.
+
+**Number Systems:** Binary, Hexadecimal, grouping bits, Base conversion. **Binary Arithmetic:** Addition and subtraction, Unsigned and Signed numbers. Fixed-Point Number Systems. Floating-Point Number Systems.
+
+**Basic gates:** Operation of a Logic circuit; Buffer; Gates: Inverter, AND gate, OR gate, NOR gate, NAND gate, XOR gate, XNOR gate. **Digital circuit operation:** logic levels, output dc specifications, input dc specifications, noise margins, power supplies. **Driving loads:** driving other gates, resistive loads and LEDs.
+
+**Verilog (Part 1):** HDL Abstraction; Modern digital design flow; Verilog constructs: data types, the module, Verilog operators.
+
+### Module 2 (11 hours)
+
+**Combinational Logic Design:** Boolean Algebra: Operations, Axioms, Theorems. Combinational logic analysis: Canonical SOP and POS, Minterm and Maxterm equivalence. Logic minimization: Algebraic minimization, K-map minimization, Don't cares, Code convertors.
+
+**Modeling concurrent functionality in Verilog:** Continuous assignment: Continuous Assignment with logical operators, Continuous assignment with conditional operators, Continuous assignment with delay.
+
+### Module 3 (8 hours)
+
+**MSI Logic and Digital Building Blocks.** MSI logic: Decoders (One-Hot decoder, 7 segment display decoder), Encoders, Multiplexers, Demultiplexers. Digital Building Blocks: Arithmetic Circuits: Half adder, Full adder, half subtractor, full subtractor; Comparators.
+
+**Structural design and hierarchy:** lower level module instantiation, gate level primitives, user defined primitives, adding delay to primitives.
+
+### Module 4 (14 hours)
+
+**Sequential Logic Design:** Latches and Flip-Flops: SR latch, SR latch with enable, JK flipflop, D flipflop, Register Enabled Flip-Flop, Resettable Flip-Flop. Sequential logic timing considerations. Common circuits based on sequential storage devices: toggle flop clock divider, asynchronous ripple counter, shift register.
+
+**Finite State Machines:** logic synthesis for an FSM, FSM design process and design examples. Synchronous Sequential Circuits: Counters.
+
+**Verilog (Part 2):** Procedural assignment; Conditional Programming constructs; Test benches; Modeling a D flipflop in Verilog; Modeling an FSM in Verilog.
+
+## Course Outcomes
+
+At the end of the course students should be able to:
+
+- **CO1:** Summarize the basic concept of different number systems and perform conversion and arithmetic operations between different bases [K2]
+- **CO2:** Interpret a combinational logic circuit to determine its logic expression, truth table, and timing information and to synthesize a minimal logic circuit through algebraic manipulation or with a Karnaugh map [K2]
+- **CO3:** Illustrate the fundamental role of hardware description languages in modern digital design and be able to develop the hardware models for different digital circuits [K3]
+- **CO4:** Develop MSI logic circuits using both the classical digital design approach and the modern HDL-based approach [K3]
+- **CO5:** Develop common circuits based on sequential storage devices including counter, shift registers and a finite state machine using the classical digital design approach and an HDL-based structural approach [K3]
+
+## Text Books
+
+- *Introduction to Logic Circuits & Logic Design with Verilog* – Brock J. LaMeres, Springer International Publishing, 2/e, 2017
+- *Digital Design and Computer Architecture, RISC-V Edition* – Sarah L. Harris, David Harris, Morgan Kaufmann, 1/e, 2022
+
+## Reference Books
+
+- *Digital Design with an Introduction to the Verilog HDL, VHDL, and System Verilog* – M Morris Mano, Michael D Ciletti, Pearson, 6/e, 2018
+- *Digital Fundamentals* – Thomas Floyd, Pearson, 11/e, 2015
+- *Fundamentals of Digital Logic with Verilog Design* – Stephen Brown, Zvonko Vranesic, McGrawHill, 3/e, 2014
+- *Switching and Finite Automata Theory* – Zvi Kohavi, Niraj K. Jha, Cambridge University Press, 3/e, 2010


### PR DESCRIPTION
Step 3 of 4 in the CSD Semester 3 correction. Unlike #207 and #209 this is not a fix to an existing record: **the course had no file at all.**

## Evidence

Source: KTU B.Tech Full Time 2024 Scheme, official Computer Science and Design syllabus PDF.

```
908  Course Code  GAEST305   DIGITAL ELECTRONICS AND LOGIC DESIGN
     (Common to Group A)
     Credits 4 · 3:1:0:0 · Course Type Theory · No prerequisites
```

Line 908 sits inside the Semester 3 block, which ends at line 2147 where Semester 4 begins. This is a **4-credit core theory course**, the largest single course in the semester, and students browsing CSD Semester 3 have never seen it.

## What is in the record

Extracted from the document, not summarized:

- Two stated course objectives
- Four modules with contact hours (11, 11, 8, 14)
- Five course outcomes with Bloom levels
- Two text books and four reference books

## Folder state after this PR

```
01.md  gamat301      06.md  pccsl307
02.md  pccst302      07.md  pccsl308
03.md  pccst303      08.md  oecs301
04.md  pbcst304      09.md  gaest305   ← this PR
05.md  uchut347
```

Duplicate check across all nine files: none.

Added as `09.md` rather than renumbering. The existing numbering is not document order anyway (`05` is `uchut347`, which appears at line 1350, after `gaest305` at 908), so renumbering would churn eight files to no benefit.

## Validation

```
checked 1 file(s): 0 error(s), 0 warning(s)
```

No shadowed frontmatter, no em dashes.

## Where this leaves CSD Semester 3

Comparing the folder against the document's S3 block, every official course is now present with the correct code:

| Official | File |
|---|---|
| GAMAT301 Mathematics for CIS-3 | 01 |
| PCCST302 Theory of Computation | 02 |
| PCCST303 Data Structures and Algorithms | 03 |
| PBCST304 Object Oriented Programming | 04 |
| GAEST305 Digital Electronics and Logic Design | **09** |
| UCHUT347 Engineering Ethics (S3/S4) | 05 |
| PCCSL307 Data Structures Lab | 06 |
| PCCSL308 Digital Lab | 07 |

One file remains unaccounted for: `08.md` `oecs301`, which appears **zero times** in the document. That is the last open item in this series.