### PR TITLE
fix(uchut346): Economics for Engineers, replacing an older-scheme record (ECE + Chemical)

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/chemical-engineering/2024/s03/05.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/chemical-engineering/2024/s03/05.md
@@ -1,68 +1,79 @@
 ---
-
 country: "india"
 university: "ktu"
 branch: "chemical-engineering"
 version: "2024"
 semester: 3
 course_code: "uchut346"
-course_title: "engineering-economics"
+course_title: "economics-for-engineers"
 language: "english"
 contributor: "@arya3077"
-
+provenance: "extracted-from-official-pdf"
+source: "KTU B.Tech Full Time 2024 Scheme, official branch syllabus PDF"
 ---
 
-# UCHUT346 - Engineering Economics
+# UCHUT346: Economics for Engineers
+
+**Course type:** Theory · **Credits:** 2 · **Teaching hours/week (L:T:P:R):** 2:0:0:0
+
+Offered in Semester 3 or Semester 4. No prerequisites.
 
 ## Course Objectives
 
-1. Understanding of finance and costing for engineering operation, budgetary planning and control.  
-2. Provide fundamental concept of micro and macroeconomics related to engineering industry.  
-3. Deliver the basic concepts of Value Engineering.  
+1. To provide students with an understanding of fundamental economic principles essential for effective decision-making in engineering contexts.
+2. To enable students to apply economic analysis to production decisions, cost management, and market strategies in engineering practice.
+3. To equip students with the ability to evaluate macroeconomic scenarios, financial methods, and investment decisions relevant to engineering projects.
 
----
+## Course Modules
 
-## Syllabus Modules
+### Module 1 (6 hours)
 
-### Module 1: Basic Economics Concepts
-- Basic economic problems, Production Possibility Curve, Utility, Law of Diminishing Marginal Utility.  
-- Law of Demand, Law of Supply, Elasticity – measurement and applications.  
-- Equilibrium, changes in demand and supply and their effects.  
-- Production function – Law of Variable Proportion, Economies of Scale – Internal and External Economies.  
-- Cobb-Douglas Production Function.  
+Basic economic problems. Production Possibility Curve. Utility. Law of diminishing marginal utility.
 
----
+**Demand:** Factors determining demand, Law of Demand, Demand curve, Price elasticity of demand, measurement of price elasticity and its applications.
 
-### Module 2: Cost Concepts & Market Structures
-- Cost concepts – social cost, private cost, explicit and implicit cost, sunk cost, opportunity cost, short-run cost curves.  
-- Revenue concepts, firms and their objectives, types of firms.  
-- Markets – Perfect Competition, Monopoly, Monopolistic Competition, Oligopoly (features and equilibrium of a firm).  
+**Supply:** Factors determining supply, Law of supply, Supply curve, Equilibrium price determination, Changes in demand and supply and its effects on equilibrium price and quantity.
 
----
+**Production:** Production function, Law of variable proportion, Returns to scale, Cobb-Douglas Production Function.
 
-### Module 3: Monetary System & National Income
-- Monetary system – money and functions, central banking.  
-- Inflation – causes, effects, control measures, monetary and fiscal policies.  
-- Deflation.  
-- Taxation – direct and indirect taxes (merits and demerits), GST.  
-- National income – concepts, circular flow, methods of estimation, difficulties.  
-- Stock market – functions, problems faced by Indian stock market, Demat and trading accounts, indicators – SENSEX, NIFTY.  
+### Module 2 (6 hours)
 
----
+**Cost:** Cost concepts, Private cost and social cost, Sunk cost, Opportunity cost, Explicit and implicit cost, Short run cost curves, Long run average cost curve, Revenue concepts, Break-even point.
 
-### Module 4: Value Engineering & Financial Analysis
-- Value analysis and value engineering – cost value, exchange value, use value, esteem value.  
-- Aims, advantages, and application areas of value engineering.  
-- Value engineering procedure.  
-- Break-even analysis, cost-benefit analysis, capit
+**Market:** Perfect Competition, Monopoly, Monopolistic Competition (features and equilibrium of a firm), Oligopoly, Features, Kinked demand model.
 
----
+### Module 3 (6 hours)
+
+**National income:** Concepts (GDP, GNP and NNP), Final goods and Intermediate goods, Methods of Estimation: output method, expenditure method. Difficulties in the measurement of national income.
+
+**Inflation:** Causes and Effects, Measures to Control Inflation, Monetary and Fiscal policies, Repo and reverse repo rate.
+
+### Module 4 (6 hours)
+
+**Value Analysis and Value Engineering:** Cost Value, Exchange Value, Use Value, Esteem Value. Aims, Advantages and Application areas of Value Engineering. Value Engineering Procedure.
+
+**Capital Budgeting:** Time value of money, Net Present Value Method, Benefit Cost Ratio, Internal Rate of Return, Payback, Accounting Rate of Return.
+
+## Course Outcomes
+
+At the end of the course students should be able to:
+
+- **CO1:** Understand the fundamentals of various economic issues using laws and learn the concepts of demand, supply, elasticity and production function [K2]
+- **CO2:** Develop decision making capability by applying concepts relating to costs and revenue, and acquire knowledge regarding the functioning of firms in different market situations [K3]
+- **CO3:** Outline the macroeconomic principles of monetary and fiscal systems and national income [K2]
+- **CO4:** Make use of the possibilities of value analysis and engineering, and take investment decisions through capital budgeting techniques [K3]
+
+## Text Books
+
+- *Managerial Economics* – Geetika, Piyali Ghosh and Chodhury, Tata McGraw Hill, 2015
+- *Engineering Economy* – H. G. Thuesen, W. J. Fabrycky, PHI, 1966
+- *Engineering Economics* – R. Paneerselvam, PHI, 2012
+- *Financial Management* – I M Pandey, Vikas Publishing House, 2015
+
 ## Reference Books
 
-- *Engineering Economy* – Leland Blank P.E., Anthony Tarquin P.E., McGraw Hill, 7/e  
-- *Indian Financial System* – M.Y. Khan, Tata McGraw Hill, 2011  
-- *Engineering Economics and Analysis* – Donald G. Newman, Jerome P. Lavelle, Engg. Press, Texas, 2002  
-- *Contemporary Engineering Economics* – Chan S. Park, Prentice Hall of India Ltd, 2001  
-- *Managerial Economics* – Geetika, Piyali Ghosh, Chodhury, Tata McGraw Hill, 2015  
-- *Engineering Economy* – H.G. Thuesen, W.J. Fabrycky, PHI, 1966  
-- *Engineering Economics* – R. Paneerselvam, PHI, 2012  
+- *Engineering Economy* – Leland Blank P.E, Anthony Tarquin P.E., McGraw Hill, 7/e
+- *Indian Financial System* – Khan M. Y., Tata McGraw Hill, 2011
+- *Engineering Economics and Analysis* – Donald G. Newman, Jerome P. Lavelle, Engg. Press, Texas, 2002
+- *Contemporary Engineering Economics* – Chan S. Park, Prentice Hall of India Ltd, 2001
+- *Financial Management: Theory and Practice* – Prasanna Chandra, McGraw Hill, 2007

--- a/universities/a-p-j-abdul-kalam-technological-university/electronics-and-communication-engineering/2024/s03/06.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/electronics-and-communication-engineering/2024/s03/06.md
@@ -1,68 +1,79 @@
 ---
-
 country: "india"
 university: "ktu"
-branch: "ece"
+branch: "electronics-and-communication-engineering"
 version: "2024"
 semester: 3
 course_code: "uchut346"
-course_title: "engineering-economics"
+course_title: "economics-for-engineers"
 language: "english"
 contributor: "@arya3077"
-
+provenance: "extracted-from-official-pdf"
+source: "KTU B.Tech Full Time 2024 Scheme, official branch syllabus PDF"
 ---
 
-# UCHUT346 - Engineering Economics
+# UCHUT346: Economics for Engineers
+
+**Course type:** Theory · **Credits:** 2 · **Teaching hours/week (L:T:P:R):** 2:0:0:0
+
+Offered in Semester 3 or Semester 4. No prerequisites.
 
 ## Course Objectives
 
-1. Understanding of finance and costing for engineering operation, budgetary planning and control.  
-2. Provide fundamental concept of micro and macroeconomics related to engineering industry.  
-3. Deliver the basic concepts of Value Engineering.  
+1. To provide students with an understanding of fundamental economic principles essential for effective decision-making in engineering contexts.
+2. To enable students to apply economic analysis to production decisions, cost management, and market strategies in engineering practice.
+3. To equip students with the ability to evaluate macroeconomic scenarios, financial methods, and investment decisions relevant to engineering projects.
 
----
+## Course Modules
 
-## Syllabus Modules
+### Module 1 (6 hours)
 
-### Module 1: Basic Economics Concepts
-- Basic economic problems, Production Possibility Curve, Utility, Law of Diminishing Marginal Utility.  
-- Law of Demand, Law of Supply, Elasticity – measurement and applications.  
-- Equilibrium, changes in demand and supply and their effects.  
-- Production function – Law of Variable Proportion, Economies of Scale – Internal and External Economies.  
-- Cobb-Douglas Production Function.  
+Basic economic problems. Production Possibility Curve. Utility. Law of diminishing marginal utility.
 
----
+**Demand:** Factors determining demand, Law of Demand, Demand curve, Price elasticity of demand, measurement of price elasticity and its applications.
 
-### Module 2: Cost Concepts & Market Structures
-- Cost concepts – social cost, private cost, explicit and implicit cost, sunk cost, opportunity cost, short-run cost curves.  
-- Revenue concepts, firms and their objectives, types of firms.  
-- Markets – Perfect Competition, Monopoly, Monopolistic Competition, Oligopoly (features and equilibrium of a firm).  
+**Supply:** Factors determining supply, Law of supply, Supply curve, Equilibrium price determination, Changes in demand and supply and its effects on equilibrium price and quantity.
 
----
+**Production:** Production function, Law of variable proportion, Returns to scale, Cobb-Douglas Production Function.
 
-### Module 3: Monetary System & National Income
-- Monetary system – money and functions, central banking.  
-- Inflation – causes, effects, control measures, monetary and fiscal policies.  
-- Deflation.  
-- Taxation – direct and indirect taxes (merits and demerits), GST.  
-- National income – concepts, circular flow, methods of estimation, difficulties.  
-- Stock market – functions, problems faced by Indian stock market, Demat and trading accounts, indicators – SENSEX, NIFTY.  
+### Module 2 (6 hours)
 
----
+**Cost:** Cost concepts, Private cost and social cost, Sunk cost, Opportunity cost, Explicit and implicit cost, Short run cost curves, Long run average cost curve, Revenue concepts, Break-even point.
 
-### Module 4: Value Engineering & Financial Analysis
-- Value analysis and value engineering – cost value, exchange value, use value, esteem value.  
-- Aims, advantages, and application areas of value engineering.  
-- Value engineering procedure.  
-- Break-even analysis, cost-benefit analysis, capit
+**Market:** Perfect Competition, Monopoly, Monopolistic Competition (features and equilibrium of a firm), Oligopoly, Features, Kinked demand model.
 
----
+### Module 3 (6 hours)
+
+**National income:** Concepts (GDP, GNP and NNP), Final goods and Intermediate goods, Methods of Estimation: output method, expenditure method. Difficulties in the measurement of national income.
+
+**Inflation:** Causes and Effects, Measures to Control Inflation, Monetary and Fiscal policies, Repo and reverse repo rate.
+
+### Module 4 (6 hours)
+
+**Value Analysis and Value Engineering:** Cost Value, Exchange Value, Use Value, Esteem Value. Aims, Advantages and Application areas of Value Engineering. Value Engineering Procedure.
+
+**Capital Budgeting:** Time value of money, Net Present Value Method, Benefit Cost Ratio, Internal Rate of Return, Payback, Accounting Rate of Return.
+
+## Course Outcomes
+
+At the end of the course students should be able to:
+
+- **CO1:** Understand the fundamentals of various economic issues using laws and learn the concepts of demand, supply, elasticity and production function [K2]
+- **CO2:** Develop decision making capability by applying concepts relating to costs and revenue, and acquire knowledge regarding the functioning of firms in different market situations [K3]
+- **CO3:** Outline the macroeconomic principles of monetary and fiscal systems and national income [K2]
+- **CO4:** Make use of the possibilities of value analysis and engineering, and take investment decisions through capital budgeting techniques [K3]
+
+## Text Books
+
+- *Managerial Economics* – Geetika, Piyali Ghosh and Chodhury, Tata McGraw Hill, 2015
+- *Engineering Economy* – H. G. Thuesen, W. J. Fabrycky, PHI, 1966
+- *Engineering Economics* – R. Paneerselvam, PHI, 2012
+- *Financial Management* – I M Pandey, Vikas Publishing House, 2015
+
 ## Reference Books
 
-- *Engineering Economy* – Leland Blank P.E., Anthony Tarquin P.E., McGraw Hill, 7/e  
-- *Indian Financial System* – M.Y. Khan, Tata McGraw Hill, 2011  
-- *Engineering Economics and Analysis* – Donald G. Newman, Jerome P. Lavelle, Engg. Press, Texas, 2002  
-- *Contemporary Engineering Economics* – Chan S. Park, Prentice Hall of India Ltd, 2001  
-- *Managerial Economics* – Geetika, Piyali Ghosh, Chodhury, Tata McGraw Hill, 2015  
-- *Engineering Economy* – H.G. Thuesen, W.J. Fabrycky, PHI, 1966  
-- *Engineering Economics* – R. Paneerselvam, PHI, 2012  
+- *Engineering Economy* – Leland Blank P.E, Anthony Tarquin P.E., McGraw Hill, 7/e
+- *Indian Financial System* – Khan M. Y., Tata McGraw Hill, 2011
+- *Engineering Economics and Analysis* – Donald G. Newman, Jerome P. Lavelle, Engg. Press, Texas, 2002
+- *Contemporary Engineering Economics* – Chan S. Park, Prentice Hall of India Ltd, 2001
+- *Financial Management: Theory and Practice* – Prasanna Chandra, McGraw Hill, 2007


### PR DESCRIPTION
Step 4 of 4 in the KTU 2024 correction series. Two files, no ordering dependency between them or on the CSD work.

## Evidence

All four official 2024 branch documents you supplied carry the same header, character for character:

```
SEMESTER S3/S4
ECONOMICS FOR ENGINEERS
Course Code  UCHUT346  CIE Marks 50
Credits 2 · 2:0:0:0 · Course Type Theory · No prerequisites
```

## Scope note: this was not a title fix

I opened these expecting a one-word change. The body turned out to be **a different syllabus**, not a mis-titled one.

Content present in the file but **absent from the 2024 UCHUT346**:

- Taxation, direct and indirect taxes, GST
- Deflation
- Monetary system, money and functions, central banking
- Stock market, Demat and trading accounts, SENSEX, NIFTY

Content in the official Module 4 but **missing from the file**:

- **Capital Budgeting** in full: time value of money, Net Present Value, Benefit Cost Ratio, Internal Rate of Return, Payback, Accounting Rate of Return

The official Module 3 is National Income and Inflation. The file's Module 3 is a monetary-system and stock-market module. These are different courses. The shape matches an earlier KTU scheme, so this looks like content carried forward rather than anything invented.

It was also **truncated mid-word**: Module 4 ended at `"cost-benefit analysis, capit"`. A student revising Module 4 got a sentence that stops in the middle of "capital", with the entire capital budgeting topic missing.

## What the records now contain

Extracted from the official document: three objectives, four modules at 6 contact hours each, four course outcomes with Bloom levels, four text books and five reference books.

Both files are byte-identical apart from the `branch` field.

## Also fixed

The ECE file declared `branch: "ece"` while sitting in `electronics-and-communication-engineering/`, a long-standing validator warning. Now consistent.

## Validation

```
checked 2 file(s): 0 error(s), 0 warning(s)
```

Zero **warnings** as well as zero errors, which is what clears the branch mismatch above. No em dashes.

## Attribution

`@arya3077` retained as contributor on both.

## Not covered here, needs its own issue

UCHUT346 is a university-common course shared across many branches. I tried to scan every 2024 branch to see how many other files carry this same older-scheme body, but the scan timed out repeatedly against the local filesystem. **The blast radius is unknown and is probably wider than these two files.** Worth a dedicated pass run in CI rather than locally.