### PR TITLE
feat: cross-file data audit, report-only in CI (#214)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,52 @@
+name: Data Audit
+
+# Cross-file checks that validate.py cannot make, because every defect it
+# looks for is spread across two or more individually valid files. See #214.
+#
+# Deliberately separate from validate.yml and deliberately non-blocking: the
+# audit reports a backlog that predates it, and a contributor adding one
+# syllabus file should never be failed for a duplicate code somebody else
+# introduced in 2019. Promote the error-level checks into validate.yml once
+# that backlog is cleared.
+on:
+  schedule:
+    # Weekly, off the hour. Nothing here is urgent enough for a nightly run.
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: data-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    if: github.repository == 'The-Purple-Movement/WikiSyllabus'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Audit regression tests
+        run: python3 scripts/tests/test_audit.py
+
+      - name: Audit the commons
+        # Non-blocking on purpose. The step summary is the deliverable; the
+        # exit code is recorded below so the run is still honest about it.
+        id: audit
+        continue-on-error: true
+        run: |
+          python3 scripts/audit.py --markdown >> "$GITHUB_STEP_SUMMARY"
+          python3 scripts/audit.py > /dev/null
+
+      - name: Record the outcome
+        run: |
+          if [ "${{ steps.audit.outcome }}" = "failure" ]; then
+            echo "::warning::The data audit found errors. See the job summary."
+          else
+            echo "The data audit found no errors."
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,5 +19,11 @@ jobs:
       - name: Validator regression tests
         run: python3 scripts/tests/test_shadowed_frontmatter.py
 
+      # The audit itself runs weekly in audit.yml, not here. Its tests run on
+      # every pull request so a change to scripts/audit.py is covered before
+      # the next scheduled run, which could be six days away.
+      - name: Audit regression tests
+        run: python3 scripts/tests/test_audit.py
+
       - name: Validate every syllabus file
         run: python3 scripts/validate.py

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Cross-file data audit for the WikiSyllabus commons.
+
+`validate.py` checks each file on its own: path shape, required frontmatter,
+field consistency. It does that correctly, and it is not what this script
+replaces. Every defect found during the KTU 2024 correction series was
+individually valid and only visible when files were compared against each
+other:
+
+  - `pccst402` appeared twice in one semester while three courses were absent
+  - `pccsl305` and `oecs301` name courses that exist in no official document
+  - `uchut346` carried an older scheme's syllabus in some branches, not others
+  - two files ended a module mid-word at "cost-benefit analysis, capit"
+  - `gaest305`, a four-credit core course, had no file at all
+
+Those are the five classes this script looks for. See issue #214.
+
+Usage:
+    python3 scripts/audit.py                # audit the whole tree
+    python3 scripts/audit.py --markdown     # report for a CI job summary
+    python3 scripts/audit.py --root PATH    # audit a different tree (tests)
+
+Exit code 0 = no errors. 1 = errors found. Warnings and info never fail.
+No external dependencies.
+
+A note on tooling, because it cost real time to learn: BSD grep on macOS
+treats files containing non-ASCII bytes as binary under a C locale and
+silently reports nothing, and large local scans of this tree time out. Every
+check here reads through Python and is immune to both. Audit in CI, not by
+hand.
+"""
+import argparse
+import os
+import re
+import statistics
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from validate import PATH_RE, parse_frontmatter  # noqa: E402
+
+ERROR, WARNING, INFO = "error", "warning", "info"
+
+# A sentence that ends deliberately ends with one of these. Used only to
+# compare a section against itself, never as a house style rule.
+TERMINAL = tuple(".!?:;)]\"'’”*_`")
+
+# Below this, a module heading has a title and essentially no syllabus. Kept
+# deliberately low. A terse one-line module is a real module, and an earlier
+# threshold of 60 flagged 405 of them; only a placeholder should trip this.
+THIN_MODULE_CHARS = 25
+
+# Two files sharing a course code should describe the same course. Word-set
+# overlap, not character diff: robust to reordering and reformatting.
+DRIFT_THRESHOLD = 0.75
+
+# A semester this far below the median for the same semester across branches
+# is more likely missing a course than genuinely smaller.
+COVERAGE_SLACK = 2
+
+MODULE_HEADING = re.compile(r"^#{2,4}\s*Module\b", re.I)
+HEADING = re.compile(r"^#{1,6}\s")
+
+# Citation lists punctuate by their own rules: some entries end in a year, some
+# in a publisher, some in an edition. Judging them against a prose habit
+# produced nothing but false positives, so the truncation rule skips them.
+CITATION_HEADING = re.compile(
+    r"\b(references?|text\s*books?|textbooks?|reference\s*books?|bibliography|"
+    r"further\s+reading|video\s+links?|web\s+resources?|online\s+resources?|"
+    r"resources|links)\b", re.I)
+
+
+def body_of(text):
+    """The document below the frontmatter block."""
+    stripped = text.lstrip()
+    if not stripped.startswith("---"):
+        return stripped
+    end = stripped.find("\n---", 3)
+    return stripped[end + 4:] if end != -1 else stripped
+
+
+def sections(body):
+    """Split a body into (heading, [content lines]) pairs.
+
+    Content excludes blank lines, headings and horizontal rules, so a section
+    is judged on its prose alone.
+    """
+    out, heading, lines = [], "(preamble)", []
+    for raw in body.split("\n"):
+        line = raw.rstrip()
+        if HEADING.match(line):
+            out.append((heading, lines))
+            heading, lines = line.strip("# ").strip(), []
+        elif line.strip() and line.strip() != "---":
+            lines.append(line.strip())
+    out.append((heading, lines))
+    return [(h, ls) for h, ls in out if ls]
+
+
+def truncated_sections(body):
+    """Sections whose last line breaks the section's own punctuation habit.
+
+    The giveaway in the real case was not the missing full stop, since plenty
+    of bullet lists have none. It was that every other line in that module
+    ended with one and the last did not, because the sentence was cut off
+    mid-word. Judging each section against itself is what keeps this quiet on
+    the thousand-odd files that simply never punctuate.
+    """
+    found = []
+    for heading, lines in sections(body):
+        if CITATION_HEADING.search(heading):
+            continue                      # citations have no prose habit
+        if len(lines) < 3:
+            continue                      # too few lines to establish a habit
+        closed = [ln for ln in lines if ln.endswith(TERMINAL)]
+        if len(closed) / len(lines) < 0.7:
+            continue                      # this section does not punctuate
+        if not lines[-1].endswith(TERMINAL):
+            found.append((heading, lines[-1]))
+    return found
+
+
+def thin_modules(body):
+    """Module headings carrying almost no syllabus."""
+    found = []
+    for heading, lines in sections(body):
+        if not MODULE_HEADING.match("## " + heading):
+            continue
+        if len(" ".join(lines)) < THIN_MODULE_CHARS:
+            found.append(heading)
+    return found
+
+
+def unsafe_bytes(raw):
+    """Bytes that make this file unreadable or hazardous to downstream tools."""
+    if b"\x00" in raw:
+        return "contains NUL bytes"
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return f"is not valid UTF-8 ({exc.reason} at byte {exc.start})"
+    bad = {ch for ch in text if ord(ch) < 32 and ch not in "\t\n\r"}
+    if bad:
+        names = ", ".join(sorted(f"U+{ord(ch):04X}" for ch in bad))
+        return f"contains control characters ({names})"
+    return None
+
+
+def similarity(a, b):
+    """Jaccard overlap of the two word sets, 0.0 to 1.0."""
+    wa = set(re.findall(r"[a-z0-9]+", a.lower()))
+    wb = set(re.findall(r"[a-z0-9]+", b.lower()))
+    if not wa or not wb:
+        return 1.0 if wa == wb else 0.0
+    return len(wa & wb) / len(wa | wb)
+
+
+def collect(root):
+    """Parse every course file under root into a record."""
+    records, findings = [], []
+    for dirpath, _dirs, names in os.walk(root):
+        for name in sorted(names):
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path).replace(os.sep, "/")
+            match = PATH_RE.match(rel)
+            if not match:
+                continue                  # pyq, overview, misfiled: validate.py's job
+            try:
+                raw = open(path, "rb").read()
+            except OSError as exc:
+                findings.append((ERROR, rel, f"unreadable: {exc}"))
+                continue
+            reason = unsafe_bytes(raw)
+            if reason:
+                findings.append((ERROR, rel, reason))
+                continue
+            text = raw.decode("utf-8")
+            frontmatter, err = parse_frontmatter(text)
+            if err:
+                continue                  # validate.py already reports this
+            records.append({
+                "path": rel,
+                "university": match.group(1),
+                "branch": match.group(2),
+                "year": match.group(3),
+                "semester": match.group(4),
+                "code": (frontmatter.get("course_code") or "").lower(),
+                "title": (frontmatter.get("course_title") or "").lower(),
+                "body": body_of(text),
+            })
+    return records, findings
+
+
+def check_duplicate_codes(records):
+    """Two files in one semester claiming the same course code."""
+    groups = defaultdict(list)
+    for r in records:
+        if r["code"]:
+            key = (r["university"], r["branch"], r["year"], r["semester"])
+            groups[(key, r["code"])].append(r["path"])
+    out = []
+    for (_key, code), paths in sorted(groups.items()):
+        if len(paths) > 1:
+            others = ", ".join(sorted(paths)[1:])
+            out.append((ERROR, sorted(paths)[0],
+                        f"course code '{code}' is claimed by {len(paths)} files "
+                        f"in this semester; the generated data will carry a "
+                        f"duplicate and hide a course. Also: {others}"))
+    return out
+
+
+def by_code(records):
+    """Group by university, year and course code, across branches."""
+    groups = defaultdict(list)
+    for r in records:
+        if r["code"]:
+            groups[(r["university"], r["year"], r["code"])].append(r)
+    return groups
+
+
+def check_title_conflicts(records):
+    """One course code naming two different subjects."""
+    out = []
+    for (_uni, year, code), rs in sorted(by_code(records).items()):
+        titles = sorted({r["title"] for r in rs if r["title"]})
+        if len(titles) > 1:
+            where = ", ".join(sorted(r["path"] for r in rs))
+            out.append((ERROR, sorted(r["path"] for r in rs)[0],
+                        f"course code '{code}' ({year}) names {len(titles)} "
+                        f"different subjects: {'; '.join(titles)}. Files: {where}"))
+    return out
+
+
+def check_body_drift(records):
+    """Same course code and title, materially different syllabus."""
+    out = []
+    for (_uni, year, code), rs in sorted(by_code(records).items()):
+        if len(rs) < 2:
+            continue
+        if len({r["title"] for r in rs if r["title"]}) > 1:
+            continue                      # already an error above
+        rs = sorted(rs, key=lambda r: r["path"])
+        base = rs[0]
+        drifted = [r for r in rs[1:]
+                   if similarity(base["body"], r["body"]) < DRIFT_THRESHOLD]
+        if drifted:
+            where = ", ".join(r["path"] for r in drifted)
+            out.append((WARNING, base["path"],
+                        f"course code '{code}' ({year}) is shared across branches "
+                        f"but the syllabus text differs materially from: {where}. "
+                        f"One of them may be from an older scheme"))
+    return out
+
+
+def check_truncation_and_thinness(records):
+    out = []
+    for r in sorted(records, key=lambda r: r["path"]):
+        for heading, last in truncated_sections(r["body"]):
+            out.append((WARNING, r["path"],
+                        f"section '{heading}' may be truncated: every other line "
+                        f"ends a sentence, this one does not: ...{last[-48:]!r}"))
+        for heading in thin_modules(r["body"]):
+            out.append((WARNING, r["path"],
+                        f"module '{heading}' has a heading but almost no syllabus"))
+    return out
+
+
+def check_coverage_outliers(records):
+    """A semester holding far fewer courses than its peers in other branches.
+
+    The only signal available for a course that is missing entirely: there is
+    no list of what each branch ought to contain, so the branches are compared
+    against each other.
+    """
+    counts = defaultdict(int)
+    for r in records:
+        counts[(r["university"], r["year"], r["semester"], r["branch"])] += 1
+
+    peers = defaultdict(dict)
+    for (uni, year, sem, branch), n in counts.items():
+        peers[(uni, year, sem)][branch] = n
+
+    out = []
+    for (uni, year, sem), branches in sorted(peers.items()):
+        if len(branches) < 3:
+            continue                      # too few peers to call anything odd
+        median = statistics.median(branches.values())
+        for branch, n in sorted(branches.items()):
+            if n <= median - COVERAGE_SLACK:
+                out.append((INFO, f"universities/{uni}/{branch}/{year}/{sem}/",
+                            f"holds {n} course(s) where the median across "
+                            f"{len(branches)} branches is {median:g}; a course "
+                            f"may be missing"))
+    return out
+
+
+CHECKS = [
+    ("duplicate course codes", check_duplicate_codes),
+    ("course codes naming two subjects", check_title_conflicts),
+    ("cross-branch syllabus drift", check_body_drift),
+    ("truncated or thin sections", check_truncation_and_thinness),
+    ("semesters below their peers", check_coverage_outliers),
+]
+
+
+def run(root):
+    records, findings = collect(root)
+    grouped = [("unreadable or unsafe files", findings)]
+    for name, fn in CHECKS:
+        grouped.append((name, fn(records)))
+    return records, grouped
+
+
+def report_text(records, grouped):
+    total = {ERROR: 0, WARNING: 0, INFO: 0}
+    for _name, findings in grouped:
+        for level, path, message in findings:
+            total[level] += 1
+            label = "ERROR  " if level == ERROR else f"{level} "
+            print(f"{label} {path}: {message}")
+    print(f"\naudited {len(records)} course file(s): "
+          f"{total[ERROR]} error(s), {total[WARNING]} warning(s), "
+          f"{total[INFO]} info")
+    return total[ERROR]
+
+
+def report_markdown(records, grouped):
+    errors = sum(1 for _n, fs in grouped for f in fs if f[0] == ERROR)
+    warnings = sum(1 for _n, fs in grouped for f in fs if f[0] == WARNING)
+    infos = sum(1 for _n, fs in grouped for f in fs if f[0] == INFO)
+    print("## WikiSyllabus data audit\n")
+    print(f"Audited **{len(records)}** course files: "
+          f"**{errors}** errors, **{warnings}** warnings, **{infos}** info.\n")
+    for name, findings in grouped:
+        if not findings:
+            continue
+        print(f"### {name} ({len(findings)})\n")
+        for level, path, message in findings[:50]:
+            print(f"- **{level}** `{path}`: {message}")
+        if len(findings) > 50:
+            print(f"- ...and {len(findings) - 50} more")
+        print()
+    if not any(fs for _n, fs in grouped):
+        print("No findings.")
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default="universities")
+    parser.add_argument("--markdown", action="store_true",
+                        help="emit a report for a CI job summary")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.root):
+        print(f"no such directory: {args.root}", file=sys.stderr)
+        return 2
+
+    records, grouped = run(args.root)
+    errors = (report_markdown if args.markdown else report_text)(records, grouped)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_audit.py
+++ b/scripts/tests/test_audit.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Regression tests for the cross-file data audit.
+
+Every positive case below is a defect that actually shipped, reduced to the
+smallest tree that reproduces it. The negative cases matter more: the audit
+runs over 1700 files, so a check that cries wolf is worse than no check, and
+most of what follows exists to prove each rule stays quiet on ordinary data.
+
+Run:  python3 scripts/tests/test_audit.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import audit  # noqa: E402
+
+U = "a-p-j-abdul-kalam-technological-university"
+
+CASES = []
+
+
+def case(name, check, expected):
+    """Register a case: build a tree, run one check, count findings."""
+    def wrap(fn):
+        CASES.append((name, check, expected, fn))
+        return fn
+    return wrap
+
+
+def doc(code, title, body, branch="computer-science", semester=3):
+    return (f'---\ncountry: "india"\nuniversity: "ktu"\nbranch: "{branch}"\n'
+            f'version: "2024"\nsemester: {semester}\ncourse_code: "{code}"\n'
+            f'course_title: "{title}"\nlanguage: "english"\n'
+            f'contributor: "@someone"\n---\n\n# {code.upper()}: {title}\n\n{body}\n')
+
+
+def tree(files):
+    """Write {relative path: text} under a temp root, return the root."""
+    root = tempfile.mkdtemp()
+    for rel, text in files.items():
+        path = os.path.join(root, "universities", rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        mode = "wb" if isinstance(text, bytes) else "w"
+        with open(path, mode) as fh:
+            fh.write(text)
+    return root
+
+
+# --------------------------------------------------------------------------
+# 1. Duplicate course codes. The pccst402 defect, which reached production.
+# --------------------------------------------------------------------------
+
+@case("two files in one semester claim the same code", "duplicate", 1)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s04/02.md": doc("pccst402", "dbms", "Body."),
+        f"{U}/computer-science/2024/s04/03.md": doc("pccst402", "dbms", "Body."),
+    })
+
+
+@case("the same code in two different semesters is fine", "duplicate", 0)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "econ", "B.", semester=3),
+        f"{U}/computer-science/2024/s04/01.md": doc("uchut346", "econ", "B.", semester=4),
+    })
+
+
+@case("a common course shared across branches is fine", "duplicate", 0)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "econ", "B."),
+        f"{U}/chemical-engineering/2024/s03/01.md":
+            doc("uchut346", "econ", "B.", branch="chemical-engineering"),
+    })
+
+
+# --------------------------------------------------------------------------
+# 2. One code, two subjects. Issue #199.
+# --------------------------------------------------------------------------
+
+@case("one code naming two different subjects", "title", 1)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "economics-for-engineers", "B."),
+        f"{U}/chemical-engineering/2024/s03/01.md":
+            doc("uchut346", "engineering-economics", "B.", branch="chemical-engineering"),
+    })
+
+
+@case("the same code with the same title is fine", "title", 0)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "economics-for-engineers", "B."),
+        f"{U}/chemical-engineering/2024/s03/01.md":
+            doc("uchut346", "economics-for-engineers", "B.", branch="chemical-engineering"),
+    })
+
+
+# --------------------------------------------------------------------------
+# 3. Cross-branch drift. The uchut346 older-scheme body, PR #213.
+# --------------------------------------------------------------------------
+
+CURRENT = ("National income concepts GDP GNP NNP methods of estimation. "
+           "Inflation causes effects measures monetary fiscal repo rate. "
+           "Capital budgeting time value of money net present value payback.")
+OLD_SCHEME = ("Monetary system money functions central banking deflation. "
+              "Taxation direct indirect GST. Stock market SENSEX NIFTY demat "
+              "trading accounts problems faced by Indian stock market.")
+
+
+@case("same code and title, different scheme's syllabus", "drift", 1)
+def _():
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "economics-for-engineers", CURRENT),
+        f"{U}/chemical-engineering/2024/s03/01.md":
+            doc("uchut346", "economics-for-engineers", OLD_SCHEME, branch="chemical-engineering"),
+    })
+
+
+@case("reworded but equivalent bodies do not drift", "drift", 0)
+def _():
+    reordered = " ".join(reversed(CURRENT.split(". "))) + "."
+    return tree({
+        f"{U}/computer-science/2024/s03/01.md": doc("uchut346", "economics-for-engineers", CURRENT),
+        f"{U}/chemical-engineering/2024/s03/01.md":
+            doc("uchut346", "economics-for-engineers", reordered, branch="chemical-engineering"),
+    })
+
+
+@case("a code in one branch only cannot drift", "drift", 0)
+def _():
+    return tree({f"{U}/computer-science/2024/s03/01.md":
+                 doc("pccst302", "theory-of-computation", CURRENT)})
+
+
+# --------------------------------------------------------------------------
+# 4. Truncation. The "cost-benefit analysis, capit" defect, PR #213.
+# --------------------------------------------------------------------------
+
+@case("the real defect: last line breaks the section's punctuation habit",
+      "truncation", 1)
+def _():
+    body = ("## Module 4\n\n"
+            "- Value analysis and value engineering, cost value, use value.\n"
+            "- Aims, advantages, and application areas of value engineering.\n"
+            "- Value engineering procedure.\n"
+            "- Break-even analysis, cost-benefit analysis, capit\n")
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+@case("a bullet list that never punctuates is not truncated", "truncation", 0)
+def _():
+    body = ("## Module 1\n\n"
+            "- Logic gates, universal gates\n"
+            "- Adders, subtractors, multiplexers\n"
+            "- Flip-flops, counters, registers\n"
+            "- Simple sequential circuits using HDL\n")
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+@case("a reference list ending in a year is not truncated", "truncation", 0)
+def _():
+    body = ("## References\n\n"
+            "- *Engineering Economy* - Leland Blank, McGraw Hill, 7/e\n"
+            "- *Indian Financial System* - M.Y. Khan, Tata McGraw Hill, 2011\n"
+            "- *Engineering Economics* - R. Paneerselvam, PHI, 2012\n")
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+@case("a fully punctuated section is not truncated", "truncation", 0)
+def _():
+    body = ("## Module 2\n\n"
+            "- Cost concepts, private cost and social cost.\n"
+            "- Revenue concepts and types of firms.\n"
+            "- Markets, perfect competition and monopoly.\n")
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+@case("two lines are too few to establish a habit", "truncation", 0)
+def _():
+    # Long enough that the thin-module rule stays out of the way: this case
+    # is about the truncation rule declining to guess from two lines.
+    body = ("## Module 1\n\n"
+            "Number systems, binary and hexadecimal, base conversion.\n"
+            "Basic gates, inverter, AND gate, OR gate, NAND gate and XOR gate\n")
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+@case("a thin module heading with no syllabus", "truncation", 1)
+def _():
+    body = "## Course Modules\n\n### Module 1\n\nTBD\n"
+    return tree({f"{U}/computer-science/2024/s03/01.md": doc("x101", "t", body)})
+
+
+# --------------------------------------------------------------------------
+# 5. Unsafe bytes, and the missing-course signal (gaest305, PR #212).
+# --------------------------------------------------------------------------
+
+@case("non-ASCII text is read fine and never flagged", "unsafe", 0)
+def _():
+    body = "Credits 2 · Cost – revenue – break-even. Don’t cares."
+    return tree({f"{U}/computer-science/2024/s03/01.md":
+                 doc("x101", "t", body).encode("utf-8")})
+
+
+@case("a NUL byte is an error", "unsafe", 1)
+def _():
+    return tree({f"{U}/computer-science/2024/s03/01.md":
+                 doc("x101", "t", "Body.").encode("utf-8").replace(b"Body", b"Bo\x00dy")})
+
+
+@case("a branch missing courses against its peers", "coverage", 1)
+def _():
+    files = {}
+    for branch in ("computer-science", "chemical-engineering", "civil-engineering"):
+        for n in range(1, 6):
+            files[f"{U}/{branch}/2024/s03/0{n}.md"] = doc(
+                f"{branch[:2]}30{n}", "t", "Body.", branch=branch)
+    for n in (4, 5):                      # thin out one branch
+        del files[f"{U}/civil-engineering/2024/s03/0{n}.md"]
+    return tree(files)
+
+
+@case("branches of naturally different size are not flagged", "coverage", 0)
+def _():
+    files = {}
+    for branch in ("computer-science", "chemical-engineering", "civil-engineering"):
+        for n in range(1, 6):
+            files[f"{U}/{branch}/2024/s03/0{n}.md"] = doc(
+                f"{branch[:2]}30{n}", "t", "Body.", branch=branch)
+    del files[f"{U}/civil-engineering/2024/s03/05.md"]
+    return tree(files)
+
+
+RUNNERS = {
+    "duplicate": lambda rs, fs: audit.check_duplicate_codes(rs),
+    "title": lambda rs, fs: audit.check_title_conflicts(rs),
+    "drift": lambda rs, fs: audit.check_body_drift(rs),
+    "truncation": lambda rs, fs: audit.check_truncation_and_thinness(rs),
+    "coverage": lambda rs, fs: audit.check_coverage_outliers(rs),
+    "unsafe": lambda rs, fs: fs,
+}
+
+
+def main():
+    failed = 0
+    cwd = os.getcwd()
+    for name, check, expected, build in CASES:
+        root = build()
+        try:
+            os.chdir(root)
+            records, findings = audit.collect("universities")
+            got = len(RUNNERS[check](records, findings))
+        finally:
+            os.chdir(cwd)
+            shutil.rmtree(root, ignore_errors=True)
+        ok = got == expected
+        failed += 0 if ok else 1
+        print(f"  {'PASS' if ok else 'FAIL'}  {check:<11} "
+              f"expected={expected} got={got}  {name}")
+    print(f"\n{len(CASES) - failed}/{len(CASES)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements #214.

`validate.py` judges each file on its own and does that correctly. Every defect found during the KTU 2024 series (#207, #209, #212, #213) was **individually valid** and only visible when files were compared against each other. This adds the script that does that comparison.

## What it found on the current tree

```
audited 2384 course file(s): 48 error(s), 115 warning(s), 42 info
```

| Check | Level | Count |
|---|---|---|
| duplicate course codes in one semester | error | 15 |
| one code naming 2 or 3 different subjects | error | 33 |
| cross-branch syllabus drift | warning | 81 |
| truncated sections | warning | 25 |
| modules with a heading and no syllabus | warning | 9 |
| semesters below their peers | info | 42 |

The 15 duplicates are the same class of defect as `pccst402`, which reached production and hid three courses from students. They span 2019 and 2024, CSE, CSD, Civil, Chemical and Aeronautical.

## Why it is not blocking

`continue-on-error: true`, weekly schedule, separate workflow. **48 errors already exist.** Turning this on hard would fail every syllabus pull request from day one, punishing new contributors for a backlog they did not create. The error-level checks should move into `validate.yml` once that backlog is cleared, and the workflow comment says so.

The audit's own tests **do** run on every pull request, wired into `validate.yml`, so a change to `audit.py` is covered rather than waiting up to six days for the next scheduled run.

## On precision, since a noisy check is worse than none

My first version produced **522 warnings**. I ran it against the real tree, read the output, and found two rules misfiring:

- **Thin modules: 405 findings.** The 60-character threshold was flagging terse but legitimate modules, such as a real one-line module reading "POS Tagging, HMM Taggers, PCFGs, Parsing, NLTK usage". Lowered to 25, which flags placeholders and leaves real content alone. Now 9.
- **Truncation in citation lists.** Reference entries end in a year, a publisher or an edition, so judging them against a prose habit was pure noise. Those sections are now skipped. 36 to 25.

Net: 522 warnings to 115.

**Truncation precision is roughly half.** Several survivors are ordinary bullets in mixed-punctuation lists. I am keeping it at warning level because it caught a genuine one that nobody had noticed, in `computer-science/2024/s03/08.md`, where an experiment ends `"...to be given p"`. Tightening it further needs a way to tell a truncated word from a real one; the corpus-prefix idea is noted in the code as future work.

## How the checks work

- **Duplicate codes** and **title conflicts** are exact grouping, no heuristics.
- **Drift** compares word-set overlap (Jaccard) rather than a character diff, so reordering and reformatting do not register while a different scheme's syllabus does. Threshold 0.75.
- **Truncation** judges each section against *its own* punctuation habit, which is what keeps it quiet on the thousand-odd files that never punctuate at all.
- **Coverage** compares each branch's semester against the median for that same semester across other branches. It is the only available signal for a course that is missing entirely, since there is no machine-readable list of what should exist. This is how `gaest305` (#212) would have been caught.

## Tests

18 regression tests, all passing. Every positive case is a defect that actually shipped, reduced to the smallest tree that reproduces it. **Most cases are negative**, proving each rule stays quiet on ordinary data: a common course shared across branches, a bullet list that never punctuates, a reference list ending in a year, reworded but equivalent bodies, branches of naturally different size.

## Speed, and why this belongs in CI

```
GitHub runner / clean checkout:  0.37 seconds
Local macOS working copy:        did not finish in 9 minutes
```

Same script, same data. That gap is why the `uchut346` blast radius in #213 was never measured and why the counts in #198 and #199 are unreliable. It is now measured: **81 files** show cross-branch drift.

## Follow-ups this unblocks

- #198 and #199 should be recounted from this audit's output rather than from local greps
- The 15 duplicate codes need triage, likely the highest-value data work available
- Promote errors to blocking once the backlog is clear