### PR TITLE
ci: make the audit report retrievable after the run

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,18 +35,41 @@ jobs:
         run: python3 scripts/tests/test_audit.py
 
       - name: Audit the commons
-        # Non-blocking on purpose. The step summary is the deliverable; the
-        # exit code is recorded below so the run is still honest about it.
+        # Non-blocking on purpose; the exit code is recorded below so the run
+        # is still honest about what it found.
+        #
+        # One run, three destinations. The job summary is for whoever opens
+        # the run. The log keeps the report inside the run itself. The file
+        # becomes an artifact. The last two exist because the GitHub API does
+        # not expose job summaries: with only a summary, the findings of a
+        # scheduled run can be recovered solely by running the script again,
+        # against a tree that has moved on since.
         id: audit
         continue-on-error: true
         run: |
-          python3 scripts/audit.py --markdown >> "$GITHUB_STEP_SUMMARY"
-          python3 scripts/audit.py > /dev/null
+          set -o pipefail
+          status=0
+          python3 scripts/audit.py --markdown | tee audit-report.md || status=$?
+          cat audit-report.md >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Upload the report
+        # always(), not success(): the audit step reports failure whenever it
+        # finds errors, and that is exactly the run whose report is worth
+        # keeping.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-audit-report
+          path: audit-report.md
+          retention-days: 90
+          if-no-files-found: error
 
       - name: Record the outcome
+        if: always()
         run: |
           if [ "${{ steps.audit.outcome }}" = "failure" ]; then
-            echo "::warning::The data audit found errors. See the job summary."
+            echo "::warning::Data audit found errors. See the job summary or the data-audit-report artifact."
           else
             echo "The data audit found no errors."
           fi


### PR DESCRIPTION
Follow-up to #216, flagged in the [first audit run report](https://github.com/The-Purple-Movement/WikiSyllabus/issues/214#issuecomment-5199642200).

## The gap

`audit.yml` wrote its report **only** to `$GITHUB_STEP_SUMMARY`. The GitHub API does not expose job summaries.

That surfaced immediately: posting the first report on #214 required re-downloading the repo at the audited commit and running the script again. That works today and stops working as soon as `main` moves on, which for a weekly job means most reports would have been effectively unreadable within days.

## The fix

One run of the script, three destinations:

| Destination | For |
|---|---|
| `$GITHUB_STEP_SUMMARY` | whoever opens the run |
| the step log | keeps the report inside the run itself |
| `data-audit-report` artifact | 90 days, downloadable, quotable |

```bash
set -o pipefail
status=0
python3 scripts/audit.py --markdown | tee audit-report.md || status=$?
cat audit-report.md >> "$GITHUB_STEP_SUMMARY"
exit $status
```

Also drops the previous **double invocation**: the old step ran the script once for the summary and again for the exit code.

## Two details that would have bitten silently

**`set -o pipefail`.** GitHub Actions runs `bash -e {0}` without `pipefail`. Piping into `tee` would otherwise return `tee`'s exit code, which is always 0, so `steps.audit.outcome` would report success on every run and the `::warning::` would never fire.

**`if: always()` on the upload.** The audit step reports failure whenever it finds errors, which is precisely the run whose report is worth keeping. Without `always()` the artifact would be uploaded only when there was nothing to report.

## Verified, not assumed

Simulated the step under `bash -e` exactly as the runner invokes it, for both outcomes:

```
audit exits 0 -> step exit 0   summary written   artifact written
audit exits 1 -> step exit 1   summary written   artifact written
```

Exit code preserved in both cases, and both outputs produced even on the failing path.

`if-no-files-found: error` guards against the report silently not existing.

## Unchanged

Still weekly, still `continue-on-error`, still non-blocking. This changes only where the output goes.