### PR TITLE
fix(audit): duplicate course codes do not hide a course

### DIFF
--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -194,7 +194,19 @@ def collect(root):
 
 
 def check_duplicate_codes(records):
-    """Two files in one semester claiming the same course code."""
+    """Two files in one semester claiming the same course code.
+
+    Both records survive into the generated data and both stay reachable:
+    Beyond-Syllabus keys subjects on the file name, not the code. So this
+    does not hide a course. What it does is show a student the same code
+    twice when they are choosing an elective, and make any lookup, deep link
+    or search by code ambiguous.
+
+    Worth checking the source before assuming the repository is at fault.
+    PECST753 is printed twice in KTU's own 2024 CSE document, once for Fuzzy
+    Systems and once for Game Theory and Mechanism Design, so at least one of
+    these findings is a faithful record of a defect upstream.
+    """
     groups = defaultdict(list)
     for r in records:
         if r["code"]:
@@ -206,8 +218,9 @@ def check_duplicate_codes(records):
             others = ", ".join(sorted(paths)[1:])
             out.append((ERROR, sorted(paths)[0],
                         f"course code '{code}' is claimed by {len(paths)} files "
-                        f"in this semester; the generated data will carry a "
-                        f"duplicate and hide a course. Also: {others}"))
+                        f"in this semester; the semester list shows the same "
+                        f"code twice and lookups by code are ambiguous. "
+                        f"Also: {others}"))
     return out
 
 


### PR DESCRIPTION
Correcting a message I wrote in #216 and repeated on [the first audit report](https://github.com/The-Purple-Movement/WikiSyllabus/issues/214#issuecomment-5199642200).

All 15 duplicate findings currently print:

> the generated data will carry a duplicate and **hide a course**

**That is false.** I inferred it from the `pccst402` case without reading the downstream code.

## What I actually checked

- `generate.ts` **pushes** every file into a `subjects` array. No map, no dedupe, no overwrite.
- The subject page resolves by file name: `semester.subjects.find(sub => sub.id === subjectId)`. File names are unique, so both records stay reachable.
- Searched the whole web app for anything keyed on `code`. Nothing.

Confirmed empirically by running the generator over a fixture containing a duplicate pair: **5 files in, 5 subjects out**, both `pecst753` records present with distinct ids.

The courses missing from CSE S4 were missing because the sync had been broken since November, not because of a duplicate code. Two separate defects that I collapsed into one story.

## What the message says now

> the semester list shows the same code twice and lookups by code are ambiguous

Still an error: a code should identify one course. But the consequence is stated accurately, so nobody picking up these 15 findings goes hunting for a student-facing outage that does not exist.

## Docstring also records the PECST753 finding

`PECST753` is printed **twice in KTU's own 2024 CSE document**, once for Fuzzy Systems and once for Game Theory and Mechanism Design. The CSD document independently confirms `PECST753` is Fuzzy Systems.

So at least one of these 15 is a faithful record of an upstream defect, not a transcription error. The docstring says so, because the next person to work this list should check the source before assuming the repository is at fault.

18/18 regression tests still pass.

Paired with a build-time guard in Beyond-Syllabus.