### PR TITLE
fix(data): normalise course_title formatting to the existing kebab-case form

### DIFF
--- a/universities/a-p-j-abdul-kalam-technological-university/biomedical-engineering/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/biomedical-engineering/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "biomedical-engineering"
 version: "2019"
 semester: "2"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@diya-bhatt29"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2019/s01/03.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2019/s01/03.md
@@ -5,7 +5,7 @@ branch: "computer-science-and-engineering"
 version: "2019"
 semester: "1"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@sandra-alex"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science-and-design/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "computer-science-and-engineering"
 version: "2019"
 semester: 2
 course_code: "mat102"
-course_title: "vector-calculus,-differential-equations-and-transforms"
+course_title: "vector-calculus-differential-equations-and-transforms"
 language: "english"
 contributor: "@sandra-alex"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/computer-science/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/computer-science/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "computer-science-and-engineering"
 version: "2019"
 semester: 2
 course_code: "mat102"
-course_title: "vector-calculus,-differential-equations-and-transforms"
+course_title: "vector-calculus-differential-equations-and-transforms"
 language: "english"
 contributor: "@AVA-NTHIKA14"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/electronics-and-communication-engineering/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/electronics-and-communication-engineering/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "electronics-and-communication-engineering"
 version: "2019"
 semester: 2
 course_code: "MAT102"
-course_title: "VECTOR CALCULUS, DIFFERENTIAL EQUATIONS AND TRANSFORMS"
+course_title: "vector-calculus-differential-equations-and-transforms"
 language: "English"
 contributor: "@alwynrejicser"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/electronics-and-computer/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/electronics-and-computer/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "electronics-and-computer-engineering"
 version: "2019"
 semester: "2"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@diya-bhatt29"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/food-technology/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/food-technology/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "food-technology"
 version: "2019"
 semester: "2"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@diya-bhatt29"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/01.md
@@ -5,7 +5,7 @@ branch: "group-b"
 version: "2024"
 semester: 1
 course_code: "gymat101"
-course_title: "mathematics for electrical science and physical science - 1"
+course_title: "mathematics-for-electrical-science-and-physical-science-1"
 language: "english"
 contributor: "@indhu-subash"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/05.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/05.md
@@ -5,7 +5,7 @@ branch: "group-b"
 version: "2024"
 semester: 1
 course_code: "gxest104"
-course_title: "introduction to electrical and electronics engineering"
+course_title: "introduction-to-electrical-and-electronics-engineering"
 language: "english"
 contributor: "@indhu-subash"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/06.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/group-b/2024/s01/06.md
@@ -5,7 +5,7 @@ branch: "group-b"
 version: "2024"
 semester: 1
 course_code: "ucest105"
-course_title: "algorithmic thinking with python"
+course_title: "algorithmic-thinking-with-python"
 language: "english"
 contributor: "@indhu-subash"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/industrial-engineering/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/industrial-engineering/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "industrial-engineering"
 version: "2019"
 semester: "2"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@diya-bhatt29"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/information-technology/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/information-technology/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "information-technology"
 version: "2019"
 semester: 2
 course_code: "mat102"
-course_title: "vector-calculus,-differential-equations-and-transforms"
+course_title: "vector-calculus-differential-equations-and-transforms"
 language: "english"
 contributor: "@AVA-NTHIKA14"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/instrumentation-and-control-engineering/2019/s02/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/instrumentation-and-control-engineering/2019/s02/01.md
@@ -5,7 +5,7 @@ branch: "instrumentation-and-control-engineering"
 version: "2019"
 semester: "2"
 course_code: "cyt100"
-course_title: " engineering-chemistry"
+course_title: "engineering-chemistry"
 language: "english"
 contributor: "@diya-bhatt29"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/mechanical-engineering/2019/s04/01.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/mechanical-engineering/2019/s04/01.md
@@ -5,7 +5,7 @@ branch: "mechanical-engineering"
 version: "2019"
 semester: 4
 course_code: "mat202"
-course_title: "probability,-statistics-and-numerical-methods"
+course_title: "probability-statistics-and-numerical-methods"
 language: "english"
 contributor: "@AkhilaSunesh"
 ---

--- a/universities/a-p-j-abdul-kalam-technological-university/mechanical-engineering/2019/s05/04.md
+++ b/universities/a-p-j-abdul-kalam-technological-university/mechanical-engineering/2019/s05/04.md
@@ -5,7 +5,7 @@ branch: "mechanical-engineering"
 version: "2019"
 semester: 5
 course_code: "mcn301"
-course_title: "disaster management"
+course_title: "disaster-management"
 language: "english"
 contributor: "@AkhilaSunesh"
 ---


### PR DESCRIPTION
First batch of the cosmetic title variants from the [audit report](https://github.com/The-Purple-Movement/WikiSyllabus/issues/214#issuecomment-5199642200). **15 files, 7 course codes, one line changed in each.**

## What was wrong

Seven codes each carried two spellings of the same title, differing only in punctuation:

| Code | Before | After |
|---|---|---|
| `cyt100` | `" engineering-chemistry"` (leading space) | `"engineering-chemistry"` |
| `mat102` | `"vector-calculus,-differential-equations-and-transforms"` | `"vector-calculus-differential-equations-and-transforms"` |
| `mat102` | `"vector calculus, differential equations and transforms"` | same as above |
| `mat202` | `"probability,-statistics-and-numerical-methods"` | `"probability-statistics-and-numerical-methods"` |
| `mcn301` | `"disaster management"` | `"disaster-management"` |
| `gymat101` | `"mathematics for electrical science and physical science - 1"` | `"mathematics-for-electrical-science-and-physical-science-1"` |
| `gxest104` | `"introduction to electrical and electronics engineering"` | `"introduction-to-electrical-and-electronics-engineering"` |
| `ucest105` | `"algorithmic thinking with python"` | `"algorithmic-thinking-with-python"` |

## Nothing is invented

The selection rule was deliberately narrow. A file was only touched when **all** of these held:

1. Another file shares its course code and year
2. Exactly one spelling among them is valid kebab-case
3. The two titles are **identical once non-alphanumeric characters are stripped**

Rule 3 is what keeps this safe. It is why `est120` (`&` versus `and`) and `gxcyt122` are **not** in this batch: removing punctuation still leaves `and` as a difference, so a judgement is required and they are held back.

It is also why the genuinely different pairs are untouched. `19-101-0104` names both *basic civil engineering* and *engineering mechanics*; `rlmca133` names both *applied statistics lab* and *object oriented programming lab*. Those are real conflicts, not formatting, and need a source.

## Effect on the audit

```
before:  48 errors, 115 warnings, 42 info
after :  41 errors, 120 warnings, 42 info
```

**7 errors resolved**, one per code, and no new errors.

### The 5 extra warnings are expected, not a regression

They are exactly the 7 resolved codes minus 2, and every one is the same message: *"shared across branches but the syllabus text differs materially"*.

`check_body_drift` deliberately skips any group whose titles already conflict, so it does not report the same problem twice. With the titles now agreeing, the drift underneath becomes visible. It was always there; the title error was masking it.

That drift is real and stays on the backlog. It needs branch PDFs to resolve, so it is out of scope here.

## Verification

```
python3 scripts/validate.py   ->  2386 files, 0 errors
```

Diff is 15 files at `+1/-1` each. Only `course_title` lines changed. Body text, headings and every other frontmatter field are untouched, so the human-readable H1 in each file is unaffected.

## Remaining in this stream

- `est120`, `gxcyt122`: `&` versus `and`, needs a one-line convention decision
- `pht100`: `engineering-physics-a` versus `engineering-physics-a-(for-circuit-branches)`, a parenthetical annotation
- `19-101-0101/0102/0103`: both variants break kebab-case, so there is no existing canonical form to adopt
- The genuinely different pairs, which need source documents